### PR TITLE
Fix quick start "with arguments" example

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -42,7 +42,7 @@ the inner wrapper when the wrapped function is called.
     def with_arguments(myarg1, myarg2):
         @wrapt.decorator
         def wrapper(wrapped, instance, args, kwargs):
-            return wrapper(*args, **kwargs)
+            return wrapped(*args, **kwargs)
         return wrapper
 
     @with_arguments(1, 2)


### PR DESCRIPTION
I believe the inner call of the example should be to wrapped() not wrapper()
