### PR TITLE
Remove unnecessary check for __wrapped__

### DIFF
--- a/src/_wrappers.c
+++ b/src/_wrappers.c
@@ -1471,7 +1471,6 @@ static int WraptObjectProxy_setattro(
         WraptObjectProxyObject *self, PyObject *name, PyObject *value)
 {
     static PyObject *self_str = NULL;
-    static PyObject *wrapped_str = NULL;
     static PyObject *startswith_str = NULL;
 
     PyObject *match = NULL;
@@ -1503,17 +1502,6 @@ static int WraptObjectProxy_setattro(
         PyErr_Clear();
 
     Py_XDECREF(match);
-
-    if (!wrapped_str) {
-#if PY_MAJOR_VERSION >= 3
-        wrapped_str = PyUnicode_InternFromString("__wrapped__");
-#else
-        wrapped_str = PyString_InternFromString("__wrapped__");
-#endif
-    }
-
-    if (PyObject_RichCompareBool(name, wrapped_str, Py_EQ) == 1)
-        return PyObject_GenericSetAttr((PyObject *)self, name, value);
 
     if (PyObject_HasAttr((PyObject *)Py_TYPE(self), name))
         return PyObject_GenericSetAttr((PyObject *)self, name, value);
@@ -2319,7 +2307,7 @@ static PyObject *WraptBoundFunctionWrapper_call(
 #endif
     }
 
-    /* 
+    /*
     * We need to do things different depending on whether we are likely
     * wrapping an instance method vs a static method or class method.
     */


### PR DESCRIPTION
It's always going to be on the type object (thus get caught in the following check).

At least I think so :grin: - please let me know if I missed some edge-case here.