### PR TITLE
Removed (unnecessary) double assignment in ObjectProxy.__setattr__

### DIFF
--- a/src/wrappers.py
+++ b/src/wrappers.py
@@ -170,7 +170,6 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
                 object.__delattr__(self, '__qualname__')
             except AttributeError:
                 pass
-            object.__setattr__(self, name, value)
             try:
                 object.__setattr__(self, '__qualname__', value.__qualname__)
             except AttributeError:


### PR DESCRIPTION
duplicated with the line 168.

I would be rather surprised if this was desired, and if yes I'd ask : why is this double setattr() necessary ?