### PR TITLE
Fix modulo operator on ObjectProxy

### DIFF
--- a/src/wrapt/wrappers.py
+++ b/src/wrapt/wrappers.py
@@ -230,7 +230,7 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
         return self.__wrapped__ // other
 
     def __mod__(self, other):
-        return self.__wrapped__ ^ other
+        return self.__wrapped__ % other
 
     def __divmod__(self, other):
         return divmod(self.__wrapped__, other)


### PR DESCRIPTION
There was a mistake in the modulo operator of ObjectProxy. It was computing the xor instead.

Example test case, before the change:

    >>> 100 % 6
    4
    >>> wrapt.ObjectProxy(100) % 6
    98

After the change:

    >>> 100 % 6
    4
    >>> wrapt.ObjectProxy(100) % 6
    4

This wasn't caught on by the unit tests since the unit tests only test for 3 % 2, which happens to be equal to 3 ^ 2 (both are 1).