### PR TITLE
Fixed issue #87: Added Python 3.5 to Travis-CI builds and added Appveryor configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.5
 env:
   global:
     - COVERAGE_CMD="coverage run -m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ python: 3.5
 env:
   global:
     - COVERAGE_CMD="coverage run -m"
-    - COVERAGE_DEP=coverage
+    - COVERAGE_DEP="coverage"
 install:
   - pip install tox coveralls
 script:
-  # travis lacks python3.5
   - tox --skip-missing-interpreters
 after_script:
   - coverage combine

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  COVERAGE_CMD: "coverage run -m"
+  COVERAGE_CMD: coverage run -m
   COVERAGE_DEP: coverage
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+environment:
+  COVERAGE_CMD: "coverage run -m"
+  COVERAGE_DEP: coverage
+
+install:
+  - ps: C:\Python35-x64\python.exe -m pip install tox
+
+build: off
+
+test_script:
+  - ps: C:\Python35-x64\python.exe -m tox --skip-missing-interpreters


### PR DESCRIPTION
Resolved issue #87 . Added missing Python 3.5 interpreter to Travis-CI build and provided Appveyor configuration file (appveyor.yml) for Windows testing.

Appveryor is missing PyPy interpreter, however. It can be manually added but I am not confident enough with PowerShell scripting to do so at the moment.

Thank you.
