### PR TITLE
Fix missing sys import for getcallargs backport.

### DIFF
--- a/src/wrapt/arguments.py
+++ b/src/wrapt/arguments.py
@@ -4,6 +4,7 @@
 # of the PSF license used for Python 2.7.
 
 from inspect import getargspec, ismethod
+import sys
 
 def getcallargs(func, *positional, **named):
     """Get the mapping of arguments to values.

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -21,3 +21,10 @@ class TestArguments(unittest.TestCase):
         calculated = wrapt.getcallargs(function, 10, 20, 30, 40, 50, 60)
 
         self.assertEqual(expected, calculated)
+
+    def test_unexpected_unicode_keyword(self):
+        def function(a=2):
+            pass
+
+        kwargs = { u'b': 40 }
+        self.assertRaises(TypeError, wrapt.getcallargs, function, **kwargs)


### PR DESCRIPTION
Hi Graham,

While I was looking through the wrapt code I noticed there was a missing sys import in `src/wrapt/arguments.py`. I've added the `import sys` in, along with adding a test which exposes the error.