### PR TITLE
Fix wrapping of inherited classmethods.

### DIFF
--- a/src/wrapt/wrappers.py
+++ b/src/wrapt/wrappers.py
@@ -711,8 +711,8 @@ def resolve_path(module, name):
 
         if inspect.isclass(original):
             for cls in inspect.getmro(original):
-                if attribute in vars(original):
-                    original = vars(original)[attribute]
+                if attribute in vars(cls):
+                    original = vars(cls)[attribute]
                     break
             else:
                 original = getattr(original, attribute)


### PR DESCRIPTION
This patch includes a test for the behavior of subclasses whose parents contain wrapped classmethods.

The subclass's classmethod should be bound to the subclass, but wrapt appears to call `getattr` on the parent class before wrapping which results in the binding of the classmethod.  This behavior is described in `changes.rst` (copied below) and the implementation comments but I think there may have been a typo in the implementation.  After this patch, wrapping classmethods appears to function normally.

From `changes.rst`:
>The FunctionWrapper was not always working when applied around a method of a class type by accessing the method to be wrapped using getattr(). Instead it is necessary to access the original unbound method from the class __dict__. Updated the FunctionWrapper to work better in such situations, but also modify resolve_path() to always grab the class method from the class __dict__ when wrapping methods using wrapt.wrap_object() so wrapping is more predictable. When doing monkey patching wrapt.wrap_object() should always be used to ensure correct operation.