### PR TITLE
added jobs to build binary wheels on linux and OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,37 @@ script:
 after_script:
   - coverage combine
   - coveralls
+
+jobs:
+  include:
+    - stage: Build
+      dist: trusty
+      python: 2.7
+      sudo: required
+      services:
+        - docker
+      script: pip install cibuildwheel==0.4.1 && mkdir -p wheelhouse/${TRAVIS_TAG} && cibuildwheel --output-dir wheelhouse/${TRAVIS_TAG}
+      env:
+        - CIBW_TEST_REQUIRES=pytest
+        - CIBW_TEST_COMMAND="py.test {project}/tests"
+      after_script:
+    - os: osx
+      language: c  # Travis doesn't support Python builds on OSX, so let's lie a bit
+      script: pip install cibuildwheel==0.4.1 && mkdir -p wheelhouse/${TRAVIS_TAG} && cibuildwheel --output-dir wheelhouse/${TRAVIS_TAG}
+      env:
+        - CIBW_TEST_REQUIRES=pytest
+        - CIBW_TEST_COMMAND="py.test {project}/tests"
+      after_script:
+
+deploy:
+  provider: s3
+  access_key_id: ""
+  secret_access_key:
+    secure: ""
+  bucket: wrapt-wheels
+  skip_cleanup: true
+  local_dir: wheelhouse
+  acl: public_read
+  on:
+    repo: GrahamDumpleton/wrapt
+    tags: true


### PR DESCRIPTION
This uses the fantastic [cibuildwheel](https://github.com/joerick/cibuildwheel) to generate wheels for both OSX and Linux. It runs the test suite for every built wheel.

Additionally, added an example setup for pushing the wheels to S3 on tagged commits. These could then be pushed to PyPI. Another option would be to [automatically](https://github.com/joerick/cibuildwheel-autopypi-example) upload the wheels to PyPI.

I have a similar PR in the works for Windows, but am struggling a bit with AppVeyor. I'll open a separate PR once I figured it out.