### PR TITLE
explicit cast to avoid warnings

### DIFF
--- a/src/wrapt/_wrappers.c
+++ b/src/wrapt/_wrappers.c
@@ -192,7 +192,7 @@ static long WraptObjectProxy_hash(WraptObjectProxyObject *self)
       return -1;
     }
 
-    return PyObject_Hash(self->wrapped);
+    return (long)PyObject_Hash(self->wrapped);
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
Might solve: https://github.com/GrahamDumpleton/wrapt/issues/112

The error in Python3 pip (9) installation in Windows, is because localized compilers will be issuing a warning due to this implicit conversion. Once the warning dissapears, the output string can be encoded.