### PR TITLE
Fix test_function.py

### DIFF
--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -24,13 +24,8 @@ def function1(arg):
     return arg
 
 function1o = function1
-
-@decorators.passthru_decorator
-def function(arg):
-    '''documentation'''
-    return arg
-
-function1d = function1
+function1d = decorators.passthru_decorator(function1)
+assert(function1d is not function1o)
 
 class TestNamingFunction(unittest.TestCase):
 


### PR DESCRIPTION
Previously, due to a typo in the second function definition,
`funcion1o` and `function1d` were both pointing to the same function
`function1`, therefore the entire `TestCase` was passing trivially
because it wasn't actually checking anithing meaningful.

It's much safer to explicitly pass the function to the decorator and
not use the decorator syntax, as this requires to duplicate the
function definition and is prone to error.

Here we are not testing that the decorator syntax is working: that is
the Python developers' responsibility.