### PR TITLE
Include tests in sdist archive

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+recursive-include tests *


### PR DESCRIPTION
This allows distributions to valdiate their python stack with the wrapt and see if it will work with their versions.