### PR TITLE
Call GC_UnTrack before calling clear

### DIFF
--- a/src/wrapt/_wrappers.c
+++ b/src/wrapt/_wrappers.c
@@ -160,7 +160,7 @@ static int WraptObjectProxy_clear(WraptObjectProxyObject *self)
 
 /* ------------------------------------------------------------------------- */
 
-static void WraptObjectProxyObject_base_dealloc(
+static void WraptObjectProxy_base_dealloc(
         WraptObjectProxyObject *self,
         int (*clear_func)(WraptObjectProxyObject *))
 {
@@ -177,7 +177,7 @@ static void WraptObjectProxyObject_base_dealloc(
 static void WraptObjectProxy_dealloc(WraptObjectProxyObject *self)
 {
     int (*clear_func)(WraptObjectProxyObject *) = WraptObjectProxy_clear;
-    WraptObjectProxyObject_base_dealloc(self, clear_func);
+    WraptObjectProxy_base_dealloc(self, clear_func);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -2017,7 +2017,7 @@ static void WraptPartialCallableObjectProxy_dealloc(
 {
     int (*clear_func)(WraptObjectProxyObject *) =
     (int (*)(WraptObjectProxyObject *)) WraptPartialCallableObjectProxy_clear;
-    WraptObjectProxyObject_base_dealloc(
+    WraptObjectProxy_base_dealloc(
             (WraptObjectProxyObject *) self, clear_func);
 }
 
@@ -2274,7 +2274,7 @@ static void WraptFunctionWrapperBase_dealloc(WraptFunctionWrapperObject *self)
 {
     int (*clear_func)(WraptObjectProxyObject *) =
     (int (*)(WraptObjectProxyObject *)) WraptFunctionWrapperBase_clear;
-    WraptObjectProxyObject_base_dealloc(
+    WraptObjectProxy_base_dealloc(
             (WraptObjectProxyObject *) self, clear_func);
 }
 

--- a/src/wrapt/_wrappers.c
+++ b/src/wrapt/_wrappers.c
@@ -160,16 +160,24 @@ static int WraptObjectProxy_clear(WraptObjectProxyObject *self)
 
 /* ------------------------------------------------------------------------- */
 
-static void WraptObjectProxy_dealloc(WraptObjectProxyObject *self)
+static void WraptObjectProxyObject_base_dealloc(
+        WraptObjectProxyObject *self,
+        int (*clear_func)(WraptObjectProxyObject *))
 {
     PyObject_GC_UnTrack(self);
 
     if (self->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *)self);
 
-    WraptObjectProxy_clear(self);
+    clear_func(self);
 
     Py_TYPE(self)->tp_free(self);
+}
+
+static void WraptObjectProxy_dealloc(WraptObjectProxyObject *self)
+{
+    int (*clear_func)(WraptObjectProxyObject *) = WraptObjectProxy_clear;
+    WraptObjectProxyObject_base_dealloc(self, clear_func);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -2007,9 +2015,10 @@ static int WraptPartialCallableObjectProxy_clear(
 static void WraptPartialCallableObjectProxy_dealloc(
         WraptPartialCallableObjectProxyObject *self)
 {
-    WraptPartialCallableObjectProxy_clear(self);
-
-    WraptObjectProxy_dealloc((WraptObjectProxyObject *)self);
+    int (*clear_func)(WraptObjectProxyObject *) =
+    (int (*)(WraptObjectProxyObject *)) WraptPartialCallableObjectProxy_clear;
+    WraptObjectProxyObject_base_dealloc(
+            (WraptObjectProxyObject *) self, clear_func);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -2263,9 +2272,10 @@ static int WraptFunctionWrapperBase_clear(WraptFunctionWrapperObject *self)
 
 static void WraptFunctionWrapperBase_dealloc(WraptFunctionWrapperObject *self)
 {
-    WraptFunctionWrapperBase_clear(self);
-
-    WraptObjectProxy_dealloc((WraptObjectProxyObject *)self);
+    int (*clear_func)(WraptObjectProxyObject *) =
+    (int (*)(WraptObjectProxyObject *)) WraptFunctionWrapperBase_clear;
+    WraptObjectProxyObject_base_dealloc(
+            (WraptObjectProxyObject *) self, clear_func);
 }
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
https://github.com/GrahamDumpleton/wrapt/issues/98

Previously, classes based on WraptFunctionWrapperBase_dealloc and WraptPartialCallableObjectProxy_dealloc would clear their attributes before removing themselves from the garbage collector. In certain corner cases, this lead to seg faults. This change adds a function so that all dealloc methods follow the same pattern of removing themselves from the GC and then calling clear on their attributes.