### PR TITLE
Fix AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install tox"
+  - "%PYTHON%/Scripts/pip install -U tox"
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
 
 install:
   - "%PYTHON%/Scripts/easy_install -U pip"
-  - "%PYTHON%/Scripts/pip install -U tox"
+  - "%PYTHON%/Scripts/pip install -U tox virtualenv"
 
 build: false
 


### PR DESCRIPTION
The Python 2.7 build is failing on AppVeyor because there's an old version of pip in the virtualenv used by tox:

* https://ci.appveyor.com/project/GrahamDumpleton/wrapt/builds/26140914

Upgrading virtualenv fixes it: https://github.com/tox-dev/tox/issues/791#issuecomment-491999917

