### PR TITLE
Fix for Python 4

### DIFF
--- a/src/wrapt/decorators.py
+++ b/src/wrapt/decorators.py
@@ -6,16 +6,8 @@ as well as some commonly used decorators.
 import sys
 
 PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
-if PY3:
-    string_types = str,
-
-    import builtins
-    exec_ = getattr(builtins, "exec")
-    del builtins
-
-else:
+if PY2:
     string_types = basestring,
 
     def exec_(_code_, _globs_=None, _locs_=None):
@@ -29,6 +21,14 @@ else:
         elif _locs_ is None:
             _locs_ = _globs_
         exec("""exec _code_ in _globs_, _locs_""")
+
+else:
+    string_types = str,
+
+    import builtins
+
+    exec_ = getattr(builtins, "exec")
+    del builtins
 
 from functools import partial
 from inspect import ismethod, isclass, formatargspec

--- a/src/wrapt/wrappers.py
+++ b/src/wrapt/wrappers.py
@@ -6,12 +6,11 @@ import weakref
 import inspect
 
 PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
-if PY3:
-    string_types = str,
-else:
+if PY2:
     string_types = basestring,
+else:
+    string_types = str,
 
 def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
@@ -117,7 +116,7 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
     def __str__(self):
         return str(self.__wrapped__)
 
-    if PY3:
+    if not PY2:
         def __bytes__(self):
             return bytes(self.__wrapped__)
 
@@ -130,7 +129,7 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):
     def __reversed__(self):
         return reversed(self.__wrapped__)
 
-    if PY3:
+    if not PY2:
         def __round__(self):
             return round(self.__wrapped__)
 


### PR DESCRIPTION
~Includes PR https://github.com/GrahamDumpleton/wrapt/pull/137 to fix AppVeyor.~ (Rebased on `develop`, no longer necessary.)

---

We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule).

There's some code which checks the Python major version is exactly 3, similar to this:

```python
if sys.version_info[0] == 3:
    print("Python 3+ code")
else:
    print "Python 2 code"
```

When run on Python 4, this will run the Python 2 code! Instead, flip the check:

```python
if sys.version_info[0] == 2:
    print "Python 2 code"
else:
    print("Python 3+ code")
```

Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./src/wrapt/importer.py:10:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
./src/wrapt/wrappers.py:9:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
./src/wrapt/decorators.py:9:7: YTT201: `sys.version_info[0] == 3` referenced (python4), use `>=`
```
