### PR TITLE
Publish sdist and bdist wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install : all
 	pip install -U .
 
 package :
-	python setup.py sdist
+	python3.6 setup.py sdist bdist_wheel
 
 release : clean package
 	twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ install : all
 	pip install -U .
 
 package :
-	python3.6 setup.py sdist bdist_wheel
+	python setup.py sdist bdist_wheel
 
 release : clean package
 	twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import os
 import sys
 
+import setuptools
 from distutils.core import setup
 from distutils.core import Extension
 from distutils.command.build_ext import build_ext


### PR DESCRIPTION
The benefits of wheels are well documented. See: https://pythonwheels.com/

This change publishes the package as both a source distribution (sdist) and built distribution (bdist_wheel).