### PR TITLE
Update for fixed outer @classmethod behavior in Python 3.9

### DIFF
--- a/docs/decorators.rst
+++ b/docs/decorators.rst
@@ -641,15 +641,15 @@ When calling the wrapped function in the decorator wrapper function, the
 instance is already bound to ``wrapped`` and will be passed automatically
 as the first argument to the original wrapped function.
 
-Note that due to a bug in Python ``classmethod.__get__()``, whereby it does
-not apply the descriptor protocol to the function wrapped by ``@classmethod``,
-the above only applies where the decorator wraps the ``@classmethod``
-decorator. If the decorator is placed inside of the ``@classmethod``
-decorator, then ``instance`` will be ``None`` and the decorator wrapper
-function will see the call as being the same as a normal function. As a
-result, always place any decorator outside of the ``@classmethod``
-decorator. Hopefully this issue in Python can be addressed in a future
-Python version.
+Note that due to a bug in Python prior to 3.9 ``classmethod.__get__()``,
+whereby it does not apply the descriptor protocol to the function
+wrapped by ``@classmethod``, the above only applies where the decorator
+wraps the ``@classmethod`` decorator. If the decorator is placed inside
+of the ``@classmethod`` decorator, then ``instance`` will be ``None``
+and the decorator wrapper function will see the call as being the same
+as a normal function. As a result, always place any decorator outside of
+the ``@classmethod`` decorator if you need to support earlier Python
+versions.
 
 Decorating Static Methods
 -------------------------

--- a/tests/test_outer_classmethod.py
+++ b/tests/test_outer_classmethod.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import unittest
 import inspect
 import imp
+import sys
 
 import wrapt
 
@@ -121,20 +122,26 @@ class TestNamingOuterClassMethod(unittest.TestCase):
 class TestCallingOuterClassMethod(unittest.TestCase):
 
     def test_class_call_function(self):
-        # Test calling classmethod. The instance and class passed to the
-        # wrapper will both be None because our decorator is surrounded
-        # by the classmethod decorator. The classmethod decorator
-        # doesn't bind the method and treats it like a normal function,
-        # explicitly passing the class as the first argument with the
-        # actual arguments following that.
+        # Test calling classmethod. In Python 3.9, the class will be
+        # passed as instance.  In older versions of Python, the instance
+        # and class passed to the wrapper will both be None because our
+        # decorator is surrounded by the classmethod decorator.
+        # The classmethod decorator doesn't bind the method and treats
+        # it like a normal function, explicitly passing the class
+        # as the first argument with the actual arguments following
+        # that.
 
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
         @wrapt.decorator
         def _decorator(wrapped, instance, args, kwargs):
-            self.assertEqual(instance, None)
-            self.assertEqual(args, (Class,)+_args)
+            if sys.hexversion >= 0x03090000:
+                self.assertEqual(instance, Class)
+                self.assertEqual(args, _args)
+            else:
+                self.assertEqual(instance, None)
+                self.assertEqual(args, (Class,)+_args)
             self.assertEqual(kwargs, _kwargs)
             self.assertEqual(wrapped.__module__, _function.__module__)
             self.assertEqual(wrapped.__name__, _function.__name__)
@@ -155,20 +162,26 @@ class TestCallingOuterClassMethod(unittest.TestCase):
         self.assertEqual(result, (_args, _kwargs))
 
     def test_instance_call_function(self):
-        # Test calling classmethod via class instance. The instance
-        # and class passed to the wrapper will both be None because our
-        # decorator is surrounded by the classmethod decorator. The
-        # classmethod decorator doesn't bind the method and treats it
-        # like a normal function, explicitly passing the class as the
-        # first argument with the actual arguments following that.
+        # Test calling classmethod via class instance. In Python 3.9,
+        # the class will be passed as instance.  In older versions
+        # of Python, the instance and class passed to the wrapper will
+        # both be None because our decorator is surrounded
+        # by the classmethod decorator. The classmethod decorator
+        # doesn't bind the method and treats it like a normal function,
+        # explicitly passing the class as the first argument with
+        # the actual arguments following that.
 
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
         @wrapt.decorator
         def _decorator(wrapped, instance, args, kwargs):
-            self.assertEqual(instance, None)
-            self.assertEqual(args, (Class,)+_args)
+            if sys.hexversion >= 0x03090000:
+                self.assertEqual(instance, Class)
+                self.assertEqual(args, _args)
+            else:
+                self.assertEqual(instance, None)
+                self.assertEqual(args, (Class,)+_args)
             self.assertEqual(kwargs, _kwargs)
             self.assertEqual(wrapped.__module__, _function.__module__)
             self.assertEqual(wrapped.__name__, _function.__name__)


### PR DESCRIPTION
Hope this helps. If you prefer me to do it another way, just let me know.