### PR TITLE
Add syntax highlighting to blog posts

### DIFF
--- a/blog/01-how-you-implemented-your-python-decorator-is-wrong.md
+++ b/blog/01-how-you-implemented-your-python-decorator-is-wrong.md
@@ -72,17 +72,17 @@ Basics of a Python decorator
 
 Everyone should know what the Python decorator syntax is.
 
-```
+```python
 @function_wrapper
 def function():
     pass
 ```
 
-The ``@`` annotation to denote the application of a decorator was only
+The `@` annotation to denote the application of a decorator was only
 added in Python 2.4. It is actually though only fancy syntactic sugar. It
 is actually equivalent to writing:
 
-```
+```python
 def function():
     pass
 
@@ -108,7 +108,7 @@ Although I mentioned using function closures to implement a decorator, to
 understand how the more generic case of a function wrapper works it is more
 illustrative to show how to implement it using a class.
 
-```
+```python
 class function_wrapper(object):
     def __init__(self, wrapped):
         self.wrapped = wrapped
@@ -122,14 +122,14 @@ def function():
 
 The class instance in this example is initialised with and records the
 original function object. When the now wrapped function is called, it is
-actually the ``__call__()`` method of the wrapper object which is invoked.
+actually the `__call__()` method of the wrapper object which is invoked.
 This in turn would then call the original wrapped function.
 
 Simply passing through the call to the wrapper alone isn't particularly
 useful, so normally you would actually want to do some work either before
 or after the wrapped function is called. Or you may want to modify the
 input arguments or the result as they pass through the wrapper. This is
-just a matter of modifying the ``__call__()`` method appropriately to do
+just a matter of modifying the `__call__()` method appropriately to do
 what you want.
 
 Using a class to implement the wrapper for a decorator isn't actually that
@@ -139,11 +139,11 @@ the decorator function. When the now wrapped function is called, the nested
 function is actually being called. This in turn would again then call the
 original wrapped function.
 
-```
+```python
 def function_wrapper(wrapped):
     def _wrapper(*args, **kwargs):
         return wrapped(*args, **kwargs)
-    return _wrapper 
+    return _wrapper
 
 @function_wrapper
 def function():
@@ -161,39 +161,43 @@ Introspecting a function
 
 Now when we talk about functions, we expect them to specify properties
 which describe them as well as document what they do. These include the
-``__name__`` and ``__doc__`` attributes. When we use a wrapper though, this
+`__name__` and `__doc__` attributes. When we use a wrapper though, this
 no longer works as we expect as in the case of using a function closure,
 the details of the nested function are returned.
 
-```
+```python
 def function_wrapper(wrapped):
     def _wrapper(*args, **kwargs):
         return wrapped(*args, **kwargs)
-    return _wrapper 
+    return _wrapper
 
 @function_wrapper
 def function():
-    pass 
+    pass
+```
 
+```pycon
 >>> print(function.__name__)
 _wrapper
 ```
 
 If we use a class to implement the wrapper, as class instances do not
-normally have a ``__name__`` attribute, attempting to access the name of
+normally have a `__name__` attribute, attempting to access the name of
 the function will actually result in an AttributeError exception.
 
-```
+```python
 class function_wrapper(object):
     def __init__(self, wrapped):
         self.wrapped = wrapped
     def __call__(self, *args, **kwargs):
-        return self.wrapped(*args, **kwargs) 
+        return self.wrapped(*args, **kwargs)
 
 @function_wrapper
 def function():
-    pass 
+    pass
+```
 
+```pycon
 >>> print(function.__name__)
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
@@ -205,17 +209,17 @@ of interest from the wrapped function to the nested wrapper function. This
 will then result in the function name and documentation strings being
 correct.
 
-```
+```python
 def function_wrapper(wrapped):
     def _wrapper(*args, **kwargs):
         return wrapped(*args, **kwargs)
     _wrapper.__name__ = wrapped.__name__
     _wrapper.__doc__ = wrapped.__doc__
-    return _wrapper 
+    return _wrapper
 
 @function_wrapper
 def function():
-    pass 
+    pass
 
 >>> print(function.__name__)
 function
@@ -223,34 +227,36 @@ function
 
 Needing to manually copy the attributes is laborious, and would need to be
 updated if any further special attributes were added which needed to be
-copied. For example, we should also copy the ``__module__`` attribute, and
-in Python 3 the ``__qualname__`` and ``__annotations__`` attributes were
+copied. For example, we should also copy the `__module__` attribute, and
+in Python 3 the `__qualname__` and `__annotations__` attributes were
 added. To aid in getting this right, the Python standard library provides
-the ``functools.wraps()`` decorator which does this task for you.
+the `functools.wraps()` decorator which does this task for you.s
 
-```
-import functools 
+```python
+import functools
 
 def function_wrapper(wrapped):
     @functools.wraps(wrapped)
     def _wrapper(*args, **kwargs):
         return wrapped(*args, **kwargs)
-    return _wrapper 
+    return _wrapper
 
 @function_wrapper
 def function():
-    pass 
+    pass
+```
 
+```pycon
 >>> print(function.__name__)
 function
 ```
 
 If using a class to implement the wrapper, instead of the
-``functools.wraps()`` decorator, we would use the
-``functools.update_wrapper()`` function.
+`functools.wraps()` decorator, we would use the
+`functools.update_wrapper()` function.
 
-```
-import functools 
+```python
+import functools
 
 class function_wrapper(object):
     def __init__(self, wrapped):
@@ -261,7 +267,7 @@ class function_wrapper(object):
 ```
 
 So we might have a solution to ensuring the function name and any
-documentation string is correct in the form of ``functools.wraps()``, but
+documentation string is correct in the form of `functools.wraps()`, but
 actually we don't and this will not always work as I will show below.
 
 Now what if we want to query the argument specification for a function.
@@ -270,14 +276,16 @@ wrapped function, it returns that of the wrapper. In the case of using a
 function closure, this is the nested function. The decorator is therefore
 not signature preserving.
 
-```
-import inspect 
+```python
+import inspect
 
 def function_wrapper(wrapped): ...
 
 @function_wrapper
-def function(arg1, arg2): pass 
+def function(arg1, arg2): pass
+```
 
+```pycon
 >>> print(inspect.getargspec(function))
 ArgSpec(args=[], varargs='args', keywords='kwargs', defaults=None)
 ```
@@ -287,12 +295,14 @@ get an exception complaining that the wrapped function isn't actually a
 function. As a result it isn't possible to derive an argument specification
 at all, even though the wrapped function is actually still callable.
 
-```
-class function_wrapper(object): ... 
+```python
+class function_wrapper(object): ...
 
 @function_wrapper
-def function(arg1, arg2): pass 
+def function(arg1, arg2): pass
+```
 
+```pycon
 >>> print(inspect.getargspec(function))
 Traceback (most recent call last):
   File "...", line XXX, in <module>
@@ -303,7 +313,7 @@ TypeError: <__main__.function_wrapper object at 0x107e0ac90> is not a Python fun
 ```
 
 Another example of introspection one can do is to use
-``inspect.getsource()`` to get back the source code related to a function.
+`inspect.getsource()` to get back the source code related to a function.
 This also will fail, with it giving the source code for the nested wrapper
 function in the case of a function closure and again failing outright with
 an exception in the case of the class based wrapper.
@@ -313,39 +323,41 @@ Wrapping class methods
 
 Now, as well as normal functions, decorators can also be applied to methods
 of classes. Python even includes a couple of special decorators called
-``@classmethod`` and ``@staticmethod`` for converting normal instance
+`@classmethod` and `@staticmethod` for converting normal instance
 methods into these special method types. Methods of classes do provide a
 number of potential problems though.
 
-```
-class Class(object): 
+```python
+class Class(object):
 
     @function_wrapper
     def method(self):
-        pass 
+        pass
 
     @classmethod
     def cmethod(cls):
-        pass 
+        pass
 
     @staticmethod
     def smethod():
         pass
 ```
 
-The first is that even if using ``functools.wraps()`` or
-``functools.update_wrapper()`` in your decorator, when the decorator is
-applied around ``@classmethod`` or ``@staticmethod``, it can fail with an
+The first is that even if using `functools.wraps()` or
+`functools.update_wrapper()` in your decorator, when the decorator is
+applied around ``@classmethod` or `@staticmethod`, it can fail with an
 exception. This is because the wrappers created by these, do not have some
 of the attributes being copied.
 
-```
+```python
 class Class(object):
     @function_wrapper
     @classmethod
     def cmethod(cls):
-        pass 
+        pass
+```
 
+```
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
   File "<stdin>", line 3, in Class
@@ -364,14 +376,14 @@ callable. This need not actually be the case. A wrapped function can
 actually be what is called a descriptor, meaning that in order to get back
 a callable, the descriptor has to be correctly bound to the instance first.
 
-```
+```python
 class Class(object):
     @function_wrapper
     @classmethod
     def cmethod(cls):
-        pass 
+        pass
 
->>> Class.cmethod() 
+>>> Class.cmethod()
 Traceback (most recent call last):
   File "classmethod.py", line 15, in <module>
     Class.cmethod()
@@ -388,12 +400,12 @@ doesn't mean they are necessarily correct and will always work.
 
 The issues highlighted so far are:
 
-* Preservation of function ``__name__`` and ``__doc__``.
+* Preservation of function `__name__` and `__doc__`.
 * Preservation of function argument specification.
 * Preservation of ability to get function source code.
 * Ability to apply decorators on top of other decorators that are implemented as descriptors.
 
-The ``functools.wraps()`` function is given as a solution to the first but
+The `functools.wraps()` function is given as a solution to the first but
 doesn't always work, at least in Python 2. It doesn't help at all though
 with preserving the introspection of a functions argument specification and
 ability to get the source code for a function.

--- a/blog/02-the-interaction-between-decorators-and-descriptors.md
+++ b/blog/02-the-interaction-between-decorators-and-descriptors.md
@@ -9,13 +9,13 @@ the first post titled [How you implemented your Python decorator is wrong](
 In that first post I described a number of ways in which the traditional
 way that Python decorators are implemented is lacking. These were:
 
-* Preservation of function ``__name__`` and ``__doc__``.
+* Preservation of function `__name__` and `__doc__`.
 * Preservation of function argument specification.
 * Preservation of ability to get function source code.
 * Ability to apply decorators on top of other decorators that are implemented as descriptors.
 
-I described previously how ``functools.wraps()`` attempts to solve the problem
-with preservation of the introspection of the ``__name__`` and ``__doc__``
+I described previously how `functools.wraps()` attempts to solve the problem
+with preservation of the introspection of the `__name__` and `__doc__`
 attributes, but highlight one case in Python 2 where it can fail, and also
 note that it doesn't help with the preservation of the function argument
 specification nor the ability to access the source code.
@@ -33,16 +33,16 @@ reading up about them elsewhere.
 
 In short though, a descriptor is an object attribute with binding
 behaviour, one whose attribute access has been overridden by methods in the
-descriptor protocol. Those methods are ``__get__()``, ``__set__()``, and
-``__delete__()``. If any of those methods are defined for an object, it is
+descriptor protocol. Those methods are `__get__()`, `__set__()`, and
+`__delete__()`. If any of those methods are defined for an object, it is
 said to be a descriptor.
 
-* ``obj.attribute``
-    --> ``attribute.__get__(obj, type(obj))``
-* ``obj.attribute = value``
-     --> ``attribute.__set__(obj, value)``
-*  ``del obj.attribute``
-    --> ``attribute.__delete__(obj)``
+* `obj.attribute`
+    --> `attribute.__get__(obj, type(obj))`
+* `obj.attribute = value`
+     --> `attribute.__set__(obj, value)`
+*  `del obj.attribute`
+    --> `attribute.__delete__(obj)`
 
 What this means is that if an attribute of a class has any of these special
 methods defined, when the corresponding operation is performed on that
@@ -54,17 +54,17 @@ You may well be thinking that you have never made use of descriptors, but
 fact is that function objects are actually descriptors. When a function is
 originally added to a class definition it is as a normal function. When you
 access that function using a dotted attribute path, you are invoking the
-``__get__()`` method to bind the function to the class instance, turning it
+`__get__()` method to bind the function to the class instance, turning it
 into a bound method of that object.
 
-```
-def f(obj): pass
+```pycon
+>>> def f(obj): pass
 
 >>> hasattr(f, '__get__')
-True 
+True
 
 >>> f
-<function f at 0x10e963cf8> 
+<function f at 0x10e963cf8>
 
 >>> obj = object()
 
@@ -72,17 +72,17 @@ True
 <bound method object.f of <object object at 0x10e8ac0b0>>
 ```
 
-So when calling a method of a class, it is not the ``__call__()`` method of
-the original function object that is called, but the ``__call__()`` method
+So when calling a method of a class, it is not the `__call__()` method of
+the original function object that is called, but the `__call__()` method
 of the temporary bound object that is created as a result of accessing the
 function.
 
 You of course don't usually see all these intermediary steps and just see
 the outcome.
 
-```
+```pycon
 >>> class Object(object):
-...   def f(self): pass 
+...   def f(self): pass
 
 >>> obj = Object()
 
@@ -93,14 +93,16 @@ the outcome.
 Looking back now at the example given in the first blog post where we
 wrapped a decorator around a class method, we encountered the error:
 
-```
+```python
 class Class(object):
     @function_wrapper
     @classmethod
     def cmethod(cls):
-        pass 
+        pass
+```
 
->>> Class.cmethod() 
+```pycon
+>>> Class.cmethod()
 Traceback (most recent call last):
   File "classmethod.py", line 15, in <module>
     Class.cmethod()
@@ -109,21 +111,21 @@ Traceback (most recent call last):
 TypeError: 'classmethod' object is not callable
 ```
 
-The problem with this example was that for the ``@classmethod`` decorator
+The problem with this example was that for the `@classmethod` decorator
 to work correctly, it is dependent on the descriptor protocol being applied
-properly. This is because the ``__call__()`` method only exists on the
-result returned by ``__get__()`` when it is called, there is no
-``__call__()`` method on the ``@classmethod`` decorator itself.
+properly. This is because the `__call__()` method only exists on the
+result returned by `__get__()` when it is called, there is no
+`__call__()` method on the `@classmethod` decorator itself.
 
 More specifically, the simple type of decorator that people normally use is
 not itself honouring the descriptor protocol and applying that to the
 wrapped object to yield the bound function object which should actually be
 called. Instead it is simply calling the wrapped object directly, which
-will fail if it doesn't have a ``__call__()``.
+will fail if it doesn't have a `__call__()`.
 
 Why then does applying a decorator to a normal instance method still work?
 
-This still works because a normal function still has a ``__call__()``
+This still works because a normal function still has a `__call__()`
 method. In bypassing the descriptor protocol of the wrapped function it is
 calling this. Although the binding protocol is side stepped, things still
 work out because the wrapper will pass the 'self' argument for the instance
@@ -132,7 +134,7 @@ object.
 
 For a normal instance method the result in this situation is effectively
 the same. It only falls apart when the wrapped object, as in the case of
-``@classmethod``, are dependent on the descriptor protocol being applied
+`@classmethod`, are dependent on the descriptor protocol being applied
 correctly.
 
 Wrappers as descriptors
@@ -142,27 +144,27 @@ The way to solve this problem where the wrapper is not honouring the
 descriptor protocol and performing binding on the wrapped object in the
 case of a method on a class, is for wrappers to also be descriptors.
 
-```
-class bound_function_wrapper(object): 
+```python
+class bound_function_wrapper(object):
     def __init__(self, wrapped):
-        self.wrapped = wrapped 
+        self.wrapped = wrapped
     def __call__(self, *args, **kwargs):
-        return self.wrapped(*args, **kwargs) 
+        return self.wrapped(*args, **kwargs)
 
-class function_wrapper(object): 
+class function_wrapper(object):
     def __init__(self, wrapped):
-        self.wrapped = wrapped 
+        self.wrapped = wrapped
     def __get__(self, instance, owner):
         wrapped = self.wrapped.__get__( instance, owner)
-        return bound_function_wrapper(wrapped) 
+        return bound_function_wrapper(wrapped)
     def __call__(self, *args, **kwargs):
         return self.wrapped(*args, **kwargs)
 ```
 
-If the wrapper is applied to a normal function, the ``__call__()`` method
+If the wrapper is applied to a normal function, the `__call__()` method
 of the wrapper is used. If the wrapper is applied to a method of a class,
-the ``__get__()`` method is called, which returns a new bound wrapper and
-the ``__call__()`` method of that is invoked instead. This allows our
+the `__get__()` method is called, which returns a new bound wrapper and
+the `__call__()` method of that is invoked instead. This allows our
 wrapper to be used around descriptors as it propagates the descriptor
 protocol.
 
@@ -174,29 +176,29 @@ protocol as shown.
 
 The question now is how do we address the other issues that were listed.
 
-We solved naming using ``functools.wrap()``/``functools.update_wrapper()``
+We solved naming using `functools.wrap()`/`functools.update_wrapper()`
 before, but what do they do and can we still use them.
 
-Well ``wraps()`` just uses ``update_wrapper()``, so we just need to look at
+Well `wraps()` just uses `update_wrapper()`, so we just need to look at
 it.
 
-```
+```python
 WRAPPER_ASSIGNMENTS = ('__module__',
        '__name__', '__qualname__', '__doc__',
        '__annotations__')
-WRAPPER_UPDATES = ('__dict__',) 
+WRAPPER_UPDATES = ('__dict__',)
 
 def update_wrapper(wrapper, wrapped,
         assigned = WRAPPER_ASSIGNMENTS,
-        updated = WRAPPER_UPDATES): 
-    wrapper.__wrapped__ = wrapped 
+        updated = WRAPPER_UPDATES):
+    wrapper.__wrapped__ = wrapped
     for attr in assigned:
         try:
             value = getattr(wrapped, attr)
         except AttributeError:
             pass
         else:
-            setattr(wrapper, attr, value) 
+            setattr(wrapper, attr, value)
     for attr in updated:
         getattr(wrapper, attr).update(
                 getattr(wrapped, attr, {}))
@@ -206,12 +208,12 @@ What is shown here is what is in Python 3.3, although that actually has a
 bug in it, which is fixed in Python 3.4. :-)
 
 Looking at the body of the function, three things are being done. First off
-a reference to the wrapped function is saved as ``__wrapped__``. This is the
+a reference to the wrapped function is saved as `__wrapped__`. This is the
 bug, as it should be done last.
 
-The second is to copy those attributes such as ``__name__`` and ``__doc__``.
+The second is to copy those attributes such as `__name__` and `__doc__`.
 
-Finally the third thing is to copy the contents of ``__dict__`` from the
+Finally the third thing is to copy the contents of `__dict__` from the
 wrapped function into the wrapper, which could actually result in quite a
 lot of objects needing to be copied.
 
@@ -221,11 +223,11 @@ is able to be done at the point that the decorator is applied.
 With the wrapper being a descriptor though, it technically now also needs
 to be done in the bound wrapper.
 
-```
+```python
 class bound_function_wrapper(object):
     def __init__(self, wrapped):
         self.wrapped = wrapped
-        functools.update_wrapper(self, wrapped) 
+        functools.update_wrapper(self, wrapped)
 
 class function_wrapper(object):
     def __init__(self, wrapped):
@@ -244,19 +246,19 @@ The solution to the performance issue is to use what is called an object
 proxy. This is a special wrapper class which looks and behaves like what it
 wraps.
 
-```
-class object_proxy(object): 
+```python
+class object_proxy(object):
 
     def __init__(self, wrapped):
         self.wrapped = wrapped
         try:
             self.__name__= wrapped.__name__
         except AttributeError:
-            pass 
+            pass
 
     @property
     def __class__(self):
-        return self.wrapped.__class__ 
+        return self.wrapped.__class__
 
     def __getattr__(self, name):
         return getattr(self.wrapped, name)
@@ -273,21 +275,21 @@ of monkey patching.
 
 In short though, it copies limited attributes from the wrapped object to
 itself, and otherwise uses special methods, properties and
-``__getattr__()`` to fetch attributes from the wrapped object only when
+`__getattr__()` to fetch attributes from the wrapped object only when
 required thereby avoiding the need to copy across lots of attributes which
 may never actually be accessed.
 
 What we now do is derive our wrapper class from the object proxy and do
-away with calling ``update_wrapper()``.
+away with calling `update_wrapper()`.
 
-```
+```python
 class bound_function_wrapper(object_proxy):
 
     def __init__(self, wrapped):
         super(bound_function_wrapper, self).__init__(wrapped)
 
     def __call__(self, *args, **kwargs):
-        return self.wrapped(*args, **kwargs)  
+        return self.wrapped(*args, **kwargs)
 
 class function_wrapper(object_proxy):
 
@@ -296,19 +298,19 @@ class function_wrapper(object_proxy):
 
     def __get__(self, instance, owner):
         wrapped = self.wrapped.__get__( instance, owner)
-        return bound_function_wrapper(wrapped) 
+        return bound_function_wrapper(wrapped)
 
     def __call__(self, *args, **kwargs):
-        return self.wrapped(*args, **kwargs) 
+        return self.wrapped(*args, **kwargs)
 ```
 
-In doing this, attributes like ``__name__`` and ``__doc__``, when queried
+In doing this, attributes like `__name__` and `__doc__`, when queried
 from the wrapper, return the values from the wrapped function. We don't
 therefore as a result have the problem we did before where details were
 being returned from the wrapper instead.
 
 Using a transparent object proxy in this way also means that calls like
-``inspect.getargspec()`` and ``inspect.getsource()`` will now work and
+`inspect.getargspec()` and `inspect.getsource()` will now work and
 return what we expect. So we have actually managed to solve those two
 problems at the same time without any extra effort, which is a bonus.
 

--- a/blog/03-implementing-a-factory-for-creating-decorators.md
+++ b/blog/03-implementing-a-factory-for-creating-decorators.md
@@ -13,7 +13,7 @@ In the very first post I described a number of ways in which the
 traditional way that Python decorators are implemented is lacking. These
 were:
 
-* Preservation of function ``__name__`` and ``__doc__``.
+* Preservation of function `__name__` and `__doc__`.
 * Preservation of function argument specification.
 * Preservation of ability to get function source code.
 * Ability to apply decorators on top of other decorators that are implemented as descriptors.
@@ -44,19 +44,19 @@ Pattern for implementing the decorator
 Just to refresh where we got to last time, we had an implementation of an
 object proxy as:
 
-```
-class object_proxy(object): 
+```python
+class object_proxy(object):
 
     def __init__(self, wrapped):
         self.wrapped = wrapped
         try:
             self.__name__= wrapped.__name__
         except AttributeError:
-            pass 
+            pass
 
     @property
     def __class__(self):
-        return self.wrapped.__class__  
+        return self.wrapped.__class__
 
     def __getattr__(self, name):
         return getattr(self.wrapped, name)
@@ -69,32 +69,32 @@ of monkey patching.
 
 The decorator itself would then be implemented per the pattern:
 
-```
-class bound_function_wrapper(object_proxy): 
+```python
+class bound_function_wrapper(object_proxy):
 
     def __init__(self, wrapped):
-        super(bound_function_wrapper, self).__init__(wrapped) 
+        super(bound_function_wrapper, self).__init__(wrapped)
 
     def __call__(self, *args, **kwargs):
-        return self.wrapped(*args, **kwargs) 
+        return self.wrapped(*args, **kwargs)
 
-class function_wrapper(object_proxy): 
+class function_wrapper(object_proxy):
 
     def __init__(self, wrapped):
-       super(function_wrapper, self).__init__(wrapped) 
+       super(function_wrapper, self).__init__(wrapped)
 
     def __get__(self, instance, owner):
         wrapped = self.wrapped.__get__( instance, owner)
-        return bound_function_wrapper(wrapped) 
+        return bound_function_wrapper(wrapped)
 
     def __call__(self, *args, **kwargs):
-        return self.wrapped(*args, **kwargs) 
+        return self.wrapped(*args, **kwargs)
 ```
 
-When the wrapper is applied to a normal function, the ``__call__()`` method
+When the wrapper is applied to a normal function, the `__call__()` method
 of the wrapper is used. If the wrapper is applied to a method of a class,
-the ``__get__()`` method is called when the attribute is accessed, which
-returns a new bound wrapper and the ``__call__()`` method of that is
+the `__get__()` method is called when the attribute is accessed, which
+returns a new bound wrapper and the `__call__()` method of that is
 invoked instead when a call is made. This allows our wrapper to be used
 around descriptors as it propagates the descriptor protocol, also binding
 the wrapped object as necessary.
@@ -109,10 +109,10 @@ decorator to help us create decorators. This would reduce the code we need
 to write for each decorator to a single function, allowing us to simplify
 the code to just:
 
-```
+```python
 @decorator
 def my_function_wrapper(wrapped, args, kwargs):
-    return wrapped(*args, **kwargs) 
+    return wrapped(*args, **kwargs)
 
 @my_function_wrapper
 def function():
@@ -122,11 +122,11 @@ def function():
 What would this decorator factory need to look like?
 
 As it turns out, our decorator factory is quite simple and isn't really
-much different to using a ``partial()``, combining our new wrapper argument
+much different to using a `partial()`, combining our new wrapper argument
 from when the decorator is defined, with the wrapped function when the
 decorator is used and passing them into our function wrapper object.
 
-```
+```python
 def decorator(wrapper):
     @functools.wraps(wrapper)
     def _decorator(wrapped):
@@ -138,31 +138,31 @@ We now just need to amend our function wrapper implementation to delegate
 the actual execution of the wrapped object to the user supplied decorator
 wrapper function.
 
-```
-class bound_function_wrapper(object_proxy): 
+```python
+class bound_function_wrapper(object_proxy):
 
     def __init__(self, wrapped, wrapper):
         super(bound_function_wrapper, self).__init__(wrapped)
-        self.wrapper = wrapper 
+        self.wrapper = wrapper
 
     def __call__(self, *args, **kwargs):
-        return self.wrapper(self.wrapped, args, kwargs) 
+        return self.wrapper(self.wrapped, args, kwargs)
 
-class function_wrapper(object_proxy): 
+class function_wrapper(object_proxy):
 
     def __init__(self, wrapped, wrapper):
         super(function_wrapper, self).__init__(wrapped)
-        self.wrapper = wrapper 
+        self.wrapper = wrapper
 
     def __get__(self, instance, owner):
         wrapped = self.wrapped.__get__(instance, owner)
-        return bound_function_wrapper(wrapped, self.wrapper) 
+        return bound_function_wrapper(wrapped, self.wrapper)
 
     def __call__(self, *args, **kwargs):
         return self.wrapper(self.wrapped, args, kwargs)
 ```
 
-The ``__call__()`` method of our function wrapper, for when it is used
+The `__call__()` method of our function wrapper, for when it is used
 around a normal function, now just calls the user supplied decorator
 wrapper function with the wrapped function and arguments, leaving the
 calling of the wrapped function up to the user supplied decorator wrapper
@@ -170,7 +170,7 @@ function.
 
 In the case where binding a function, the wrapper is also passed to the
 bound wrapper. The bound wrapper is more or less the same, with the
-``__call__()`` method delegating to the user supplied decorator wrapper
+`__call__()` method delegating to the user supplied decorator wrapper
 function.
 
 So we can make creating decorators easier using a factory. Lets now check
@@ -188,7 +188,7 @@ To test out how our new decorator works, we can print out the args passed
 to the wrapper when the wrapped function is called and can compare the
 results.
 
-```
+```python
 @decorator
 def my_function_wrapper(wrapped, args, kwargs):
     print('ARGS', args)
@@ -197,11 +197,13 @@ def my_function_wrapper(wrapped, args, kwargs):
 
 First up lets try wrapping a normal function:
 
-```
+```python
 @my_function_wrapper
 def function(a, b):
-    pass 
+    pass
+```
 
+```pycon
 >>> function(1, 2)
 ARGS (1, 2)
 ```
@@ -211,13 +213,13 @@ called are output.
 
 What about when wrapping an instance method?
 
-```
+```python
 class Class(object):
     @my_function_wrapper
     def function_im(self, a, b):
-        pass 
+        pass
 
-c = Class() 
+c = Class()
 
 >>> c.function_im()
 ARGS (1, 2)
@@ -234,29 +236,29 @@ class as it is now associated with the bound function passed in, rather
 than the argument list.
 
 To solve this problem we can remember what the instance was that was passed
-to the ``__get__()`` method when it was called to bind the function. This
+to the `__get__()` method when it was called to bind the function. This
 can then be passed through to the bound wrapper when it is created.
 
-```
-class bound_function_wrapper(object_proxy): 
+```python
+class bound_function_wrapper(object_proxy):
 
     def __init__(self, wrapped, instance, wrapper):
         super(bound_function_wrapper, self).__init__(wrapped)
         self.instance = instance
-        self.wrapper = wrapper 
+        self.wrapper = wrapper
 
     def __call__(self, *args, **kwargs):
-        return self.wrapper(self.wrapped, self.instance, args, kwargs) 
+        return self.wrapper(self.wrapped, self.instance, args, kwargs)
 
-class function_wrapper(object_proxy): 
+class function_wrapper(object_proxy):
 
     def __init__(self, wrapped, wrapper):
         super(function_wrapper, self).__init__(wrapped)
-        self.wrapper = wrapper 
+        self.wrapper = wrapper
 
     def __get__(self, instance, owner):
         wrapped = self.wrapped.__get__( instance, owner)
-        return bound_function_wrapper(wrapped, instance, self.wrapper) 
+        return bound_function_wrapper(wrapped, instance, self.wrapper)
 
     def __call__(self, *args, **kwargs):
         return self.wrapper(self.wrapped, None, args, kwargs)
@@ -270,16 +272,18 @@ new instance argument.
 We can now modify our wrapper function for the decorator to output both the
 instance and the arguments passed.
 
-```
+```python
 @decorator
 def my_function_wrapper(wrapped, instance, args, kwargs):
     print('INSTANCE', instance)
     print('ARGS', args)
-    return wrapped(*args, **kwargs) 
+    return wrapped(*args, **kwargs)
+```
 
+```pycon
 >>> function(1, 2)
 INSTANCE None
-ARGS (1, 2) 
+ARGS (1, 2)
 
 >>> c.function_im(1, 2)
 INSTANCE <__main__.Class object at 0x1085ca9d0>
@@ -297,7 +301,7 @@ which we still need to check. This is calling an instance method by calling
 the function on the class and passing the object instance explicitly as the
 first argument.
 
-```
+```pycon
 >>> Class.function_im(c, 1, 2)
 INSTANCE None
 ARGS (<__main__.Class object at 0x1085ca9d0>, 1, 2)
@@ -314,21 +318,21 @@ calling the decorator wrapper function and pop the instance off the start
 of the argument list. We then use a partial to bind the instance to the
 wrapped function ourselves and call the decorator wrapper function.
 
-```
-class bound_function_wrapper(object_proxy): 
+```python
+class bound_function_wrapper(object_proxy):
 
     def __call__(self, *args, **kwargs):
         if self.instance is None:
             instance, args = args[0], args[1:]
             wrapped = functools.partial(self.wrapped, instance)
-            return self.wrapper(wrapped, instance, args, kwargs) 
+            return self.wrapper(wrapped, instance, args, kwargs)
         return self.wrapper(self.wrapped, self.instance, args, kwargs)
 ```
 
 We then get the same result no matter whether the instance method is called
 via the class or not.
 
-```
+```pycon
 >>> Class.function_im(c, 1, 2)
 INSTANCE <__main__.Class object at 0x1085ca9d0>
 ARGS (1, 2)
@@ -343,14 +347,16 @@ decorator was applied to an instance method of a class.
 What about other method types that a class can have, specifically class
 method and static methods.
 
-```
+```python
 class Class(object):
 
     @my_function_wrapper
     @classmethod
     def function_cm(cls, a, b):
-        pass 
+        pass
+```
 
+```pycon
 >>> Class.function_cm(1, 2)
 INSTANCE 1
 ARGS (2,)
@@ -385,7 +391,7 @@ be used in a different context.
 
 What I am instead aiming for is the ability to do:
 
-```
+```python
 @decorator
 def universal(wrapped, instance, args, kwargs):
     if instance is None:

--- a/blog/05-decorators-which-accept-arguments.md
+++ b/blog/05-decorators-which-accept-arguments.md
@@ -38,7 +38,7 @@ wrapped function was called, or modify input arguments or the result.
 This function wrapper was used in conjunction with the decorator factory
 which was also described:
 
-```
+```python
 def decorator(wrapper):
     @functools.wraps(wrapper)
     def _decorator(wrapped):
@@ -48,13 +48,13 @@ def decorator(wrapper):
 
 allowing a user to define their own decorator as:
 
-```
+```python
 @decorator
 def my_function_wrapper(wrapped, instance, args, kwargs):
     print('INSTANCE', instance)
     print('ARGS', args)
     print('KWARGS', kwargs)
-    return wrapped(*args, **kwargs) 
+    return wrapped(*args, **kwargs)
 
 @my_function_wrapper
 def function(a, b):
@@ -72,12 +72,12 @@ Using a function closure to collect arguments
 The easiest way to implement a decorator which accepts arguments is using a
 function closure.
 
-```
+```python
 def with_arguments(arg):
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
-    return _wrapper 
+    return _wrapper
 
 @with_arguments(arg=1)
 def function():
@@ -107,12 +107,12 @@ decorator, even though one would not need to pass the argument, one cannot
 avoid needing to still write it out as a distinct call. That is, you still
 need to supply empty parentheses.
 
-```
+```python
 def with_arguments(arg='default'):
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
-    return _wrapper 
+    return _wrapper
 
 @with_arguments()
 def function():
@@ -126,7 +126,7 @@ have default values and none are being supplied explicitly. In other words,
 the desire is that when there are no arguments to be passed, that one can
 write:
 
-```
+```python
 @with_arguments
 def function():
     pass
@@ -145,16 +145,16 @@ Optionally allowing decorator arguments
 To allow the decorator arguments to be optionally supplied, we can change
 the above recipe to:
 
-```
+```python
 def optional_arguments(wrapped=None, arg=1):
     if wrapped is None:
-        return functools.partial(optional_arguments, arg=arg) 
+        return functools.partial(optional_arguments, arg=arg)
 
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
 
-    return _wrapper(wrapped) 
+    return _wrapper(wrapped)
 
 @optional_arguments(arg=2)
 def function1():
@@ -162,7 +162,7 @@ def function1():
 
 @optional_arguments
 def function2():
-    pass 
+    pass
 ```
 
 With the arguments having default values, the outer decorator factory would
@@ -182,10 +182,10 @@ Now why I said a convention of having keyword arguments may perhaps be
 preferable, is that Python 3 allows you to enforce it using the new keyword
 only argument syntax.
 
-```
+```python
 def optional_arguments(wrapped=None, *, arg=1):
     if wrapped is None:
-        return functools.partial(optional_arguments, arg=arg)  
+        return functools.partial(optional_arguments, arg=arg)
 
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
@@ -199,12 +199,12 @@ decorator argument as the positional argument for wrapped. For consistency,
 keyword only arguments can also be enforced for required arguments even
 though it isn't strictly necessary.
 
-```
+```python
 def required_arguments(*, arg):
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
         return wrapped(*args, **kwargs)
-    return _wrapper  
+    return _wrapper
 ```
 
 Maintaining state between wrapper calls
@@ -224,7 +224,7 @@ There are a few ways in which this can be done.
 The first is to require that the object which maintains the state, be
 passed in as an explicit argument to the decorator.
 
-```
+```python
 def cache(d):
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
@@ -234,9 +234,9 @@ def cache(d):
         except KeyError:
             result = d[key] = wrapped(*args, **kwargs)
             return result
-    return _wrapper 
+    return _wrapper
 
-_d = {} 
+_d = {}
 
 @cache(_d)
 def function():
@@ -247,7 +247,7 @@ Unless there is a specific need to be able to pass in the state object, a
 second better way is to create the state object on the stack within the
 call of the outer function.
 
-```
+```python
 def cache(wrapped):
     d = {}
 
@@ -260,7 +260,7 @@ def cache(wrapped):
             result = d[key] = wrapped(*args, **kwargs)
             return result
 
-    return _wrapper(wrapped) 
+    return _wrapper(wrapped)
 
 @cache
 def function():
@@ -275,13 +275,13 @@ If this was a reasonable default, but you did in some cases still need to
 optionally pass the state object in as an argument, then optional decorator
 arguments could instead be used.
 
-```
+```python
 def cache(wrapped=None, d=None):
     if wrapped is None:
-        return functools.partial(cache, d=d) 
+        return functools.partial(cache, d=d)
 
     if d is None:
-        d = {} 
+        d = {}
 
     @decorator
     def _wrapper(wrapped, instance, args, kwargs):
@@ -292,17 +292,17 @@ def cache(wrapped=None, d=None):
             result = d[key] = wrapped(*args, **kwargs)
             return result
 
-    return _wrapper(wrapped) 
+    return _wrapper(wrapped)
 
 @cache
 def function1():
-    return time.time() 
+    return time.time()
 
-_d = {} 
+_d = {}
 
 @cache(d=_d)
 def function2():
-    return time.time() 
+    return time.time()
 
 @cache(d=_d)
 def function3():
@@ -315,7 +315,7 @@ Decorators as a class
 Now way back in the very first post in this series of blog posts, a way in
 which a decorator could be implemented as a class was described.
 
-```
+```python
 class function_wrapper(object):
 
     def __init__(self, wrapped):
@@ -331,7 +331,7 @@ also able to maintain state. Specifically, the constructor of the class can
 save away the state object as an attribute of the instance of the class,
 along with the reference to the wrapped function.
 
-```
+```python
 class cache(object):
 
     def __init__(self, wrapped):
@@ -344,7 +344,7 @@ class cache(object):
             return self.d[key]
         except KeyError:
             result = self.d[key] = self.wrapped(*args, **kwargs)
-            return result 
+            return result
 
 @cache
 def function():
@@ -370,15 +370,15 @@ thing with our new decorator pattern. Turns out there possibly is.
 What one should be able to do, at least for where there are required
 arguments, is do:
 
-```
-class with_arguments(object): 
+```python
+class with_arguments(object):
 
     def __init__(self, arg):
-        self.arg = arg 
+        self.arg = arg
 
     @decorator
     def __call__(self, wrapped, instance, args, kwargs):
-        return wrapped(*args, **kwargs) 
+        return wrapped(*args, **kwargs)
 
 @with_arguments(arg=1)
 def function():
@@ -388,19 +388,19 @@ def function():
 What will happen here is that application of the decorator with arguments
 being supplied, will result in an instance of the class being created. In
 the next phase where that is called with the wrapped function, the
-``__call__()`` method with ``@decorator`` applied will be used as a
+`__call__()` method with `@decorator` applied will be used as a
 decorator on the wrapped function. The end result should be that the
-``__call__()`` method of the class instance created ends up being our
+`__call__()` method of the class instance created ends up being our
 wrapper function.
 
-When the decorated function is now called, the ``__call__()`` method of the
+When the decorated function is now called, the `__call__()` method of the
 class would be called to then in turn call the wrapped function. As the
-``__call__()`` method at that point is bound to an instance of the class,
+`__call__()` method at that point is bound to an instance of the class,
 it would have access to the state that it contained.
 
 What actually happens when we do this though?
 
-```
+```pycon
 Traceback (most recent call last):
   File "test.py", line 483, in <module>
     @with_arguments(1)
@@ -415,7 +415,7 @@ by now, I don't give up that easily.
 Now the reason this failed is actually because of how our decorator factory
 is implemented.
 
-```
+```python
 def decorator(wrapper):
     @functools.wraps(wrapper)
     def _decorator(wrapped):

--- a/blog/09-performance-overhead-of-using-decorators.md
+++ b/blog/09-performance-overhead-of-using-decorators.md
@@ -25,8 +25,8 @@ function with the decorator mechanism which has been described. The
 relevant part of the decorator mechanism which comes into play in this case
 is:
 
-```
-class function_wrapper(object_proxy):  
+```python
+class function_wrapper(object_proxy):
 
     def __init__(self, wrapped, wrapper):
         super(function_wrapper, self).__init__(wrapped)
@@ -37,7 +37,7 @@ class function_wrapper(object_proxy):
         ...
 
     def __call__(self, *args, **kwargs):
-        return self.wrapper(self.wrapped, None, args, kwargs)  
+        return self.wrapper(self.wrapped, None, args, kwargs)
 
 def decorator(wrapper):
     def _wrapper(wrapped, instance, args, kwargs):
@@ -59,10 +59,10 @@ full.
 With our decorator factory, when creating a decorator and then decorating a
 normal function with it we would use:
 
-```
+```python
 @decorator
 def my_function_wrapper(wrapped, instance, args, kwargs):
-    return wrapped(*args, **kwargs)  
+    return wrapped(*args, **kwargs)
 
 @my_function_wrapper
 def function():
@@ -72,11 +72,11 @@ def function():
 This is in contrast to the same decorator created in the more traditional
 way using a function closure.
 
-```
+```python
 def my_function_wrapper(wrapped):
     def _my_function_wrapper(*args, **kwargs):
         return wrapped(*args, **kwargs)
-    return _my_function_wrapper 
+    return _my_function_wrapper
 
 @my_function_wrapper
 def function():
@@ -85,7 +85,7 @@ def function():
 
 Now what actually occurs in these two different cases when we make the call:
 
-```
+```python
 function()
 ```
 
@@ -95,12 +95,12 @@ Tracing the execution of the function
 In order to trace the execution of our code we can use Python's profile
 hooks mechanism.
 
-```
-import sys 
+```python
+import sys
 def tracer(frame, event, arg):
-    print(frame.f_code.co_name, event) 
+    print(frame.f_code.co_name, event)
 
-sys.setprofile(tracer) 
+sys.setprofile(tracer)
 
 function()
 ```
@@ -120,7 +120,7 @@ _my_function_wrapper return
 
 So what we see here is that the nested function of our function closure is
 called. This is because the decorator in the case of a using a function
-closure is replacing ``function`` with a reference to that nested function.
+closure is replacing `function` with a reference to that nested function.
 When that nested function is called, it then in turn calls the original
 wrapped function.
 
@@ -136,17 +136,17 @@ __call__ call
 __call__ return
 ```
 
-The difference here is that our decorator replaces ``function`` with an
+The difference here is that our decorator replaces `function` with an
 instance of our function wrapper class. Being a class, when it is called as
-if it was a function, the ``__call__()`` method is invoked on the instance
-of the class. The ``__call__()`` method is then invoking the user supplied
+if it was a function, the `__call__()` method is invoked on the instance
+of the class. The `__call__()` method is then invoking the user supplied
 wrapper function, which in turn calls the original wrapped function.
 
 The result therefore is that we have introduced an extra level of
 indirection, or in other words an extra function call into the execution
 path.
 
-Keep in mind though that ``__call__()`` is actually a method though and not
+Keep in mind though that `__call__()` is actually a method though and not
 just a normal function. Being a method that means there is actually a lot
 more work going on behind the scenes than a normal function call. In
 particular, the unbound method needs to be bound to the instance of our
@@ -162,22 +162,22 @@ additional method call overhead. How much actual extra overhead is this
 resulting in though?
 
 To try and measure the increase in overhead in each solution we can use the
-``timeit`` module to time the execution of our function call. As a baseline,
+`timeit` module to time the execution of our function call. As a baseline,
 we first want to time the call of a function without any decorator applied.
 
-```
-# benchmarks.py 
+```python
+# benchmarks.py
 def function():
-    pass 
+    pass
 ```
 
 To time this we use the command:
 
-```
+```sh
 $ python -m timeit -s 'import benchmarks' 'benchmarks.function()'
 ```
 
-The ``timeit`` module when used in this way will perform a suitable large
+The `timeit` module when used in this way will perform a suitable large
 number of iterations of calling the function, divide the resulting total
 time for all calls with the count of the number and end up with a time
 value for a single call.
@@ -202,7 +202,7 @@ And finally with our decorator factory:
 ```
 
 In this final case, rather than use the exact code as has been presented so
-far in this series of blog posts, I have used the ``wrapt`` module
+far in this series of blog posts, I have used the `wrapt` module
 implementation of what has been described. This implementation works
 slightly differently as it has a few extra capabilities over what has been
 described and the design is also a little bit different. The overhead will

--- a/blog/10-performance-overhead-when-applying-decorators-to-methods.md
+++ b/blog/10-performance-overhead-when-applying-decorators-to-methods.md
@@ -69,11 +69,11 @@ In this case the execution of an instance method.
 First lets check again what we would get for a decorator implemented as a
 function closure.
 
-```
+```python
 def my_function_wrapper(wrapped):
     def _my_function_wrapper(*args, **kwargs):
         return wrapped(*args, **kwargs)
-    return _my_function_wrapper 
+    return _my_function_wrapper
 
 class Class(object):
     @my_function_wrapper
@@ -108,7 +108,7 @@ different when we perform actual timing tests.
 Now for when using our decorator factory. To provide context this time we
 need to present the complete recipe for the implementation.
 
-```
+```python
 class object_proxy(object):
 
     def __init__(self, wrapped):
@@ -151,7 +151,7 @@ class bound_function_wrapper(object_proxy):
             descriptor = self.parent.wrapped.__get__(instance, owner)
             return bound_function_wrapper(descriptor, instance, self.wrapper,
                     self.binding, self.parent)
-        return self 
+        return self
 
 class function_wrapper(object_proxy):
 
@@ -163,15 +163,15 @@ class function_wrapper(object_proxy):
         elif isinstance(wrapped, staticmethod):
             self.binding = 'staticmethod'
         else:
-            self.binding = 'function' 
+            self.binding = 'function'
 
     def __get__(self, instance, owner):
         wrapped = self.wrapped.__get__(instance, owner)
         return bound_function_wrapper(wrapped, instance, self.wrapper,
-                self.binding, self) 
+                self.binding, self)
 
     def __call__(self, *args, **kwargs):
-        return self.wrapper(self.wrapped, None, args, kwargs) 
+        return self.wrapper(self.wrapped, None, args, kwargs)
 
 def decorator(wrapper):
     def _wrapper(wrapped, instance, args, kwargs):
@@ -190,7 +190,7 @@ def decorator(wrapper):
 
 With our decorator implementation now being:
 
-```
+```python
 @decorator
 def my_function_wrapper(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
@@ -216,7 +216,7 @@ is:
 ```
 
 As can be seen, due to the binding of the method to the instance of the
-class which occurs in ``__get__()``, a lot more is now happening. The
+class which occurs in `__get__()`, a lot more is now happening. The
 overhead can therefore be expected to be significantly more also.
 
 Timing execution of the method call
@@ -227,7 +227,7 @@ implementation from the wrapt library will again be used.
 
 This time our test is run as:
 
-```
+```sh
 $ python -m timeit -s 'import benchmarks; c=benchmarks.Class()' 'c.method()'
 ```
 
@@ -322,5 +322,5 @@ In the next post I will touch once again on issues of performance overhead,
 but also a bit on alternative ways of implementing a decorator so as to try
 and address the problems raised in my very first post. This will be as a
 part of a comparison between the approach described in this series of posts
-and the way in which the ``decorator`` module available from PyPi implements
+and the way in which the `decorator` module available from PyPi implements
 its variant of a decorator factory.

--- a/blog/11-safely-applying-monkey-patches-in-python.md
+++ b/blog/11-safely-applying-monkey-patches-in-python.md
@@ -52,9 +52,9 @@ Before we jump into monkey patching of arbitrary code we first need to
 recap how the wrapt package could be used to create a decorator. The
 primary pattern for this was:
 
-```
+```python
 import wrapt
-import inspect 
+import inspect
 
 @wrapt.decorator
 def universal(wrapped, instance, args, kwargs):
@@ -96,7 +96,7 @@ one in each scenario.
 Using this decorator is then no different to any other way that decorators
 would be used.
 
-```
+```python
 class Example(object):
 
     @universal
@@ -110,12 +110,12 @@ Before the '@' syntax was allowed you could still create and use
 decorators, but you had to be more explicit in applying them. That is, you
 had to write:
 
-```
+```python
 class Example(object):
 
     def name(self):
         return 'name'
-    name = universal(name) 
+    name = universal(name)
 ```
 
 This can still be done and when written this way it makes it clearer how
@@ -135,7 +135,7 @@ the function wrapper at that point.
 
 In effect you are doing:
 
-```
+```python
 class Example(object):
     def name(self):
         return 'name'
@@ -152,7 +152,7 @@ the body of the class when it is defined. In particular the access of
 'Example.name' actually invokes the descriptor protocol and so is returning
 an instance method. We can see this by running the code:
 
-```
+```python
 class Example(object):
     def name(self):
         return 'name'
@@ -186,7 +186,7 @@ function to apply it to the target function.
 The prototype for the wrapper function is the same as before, but we simply
 do not apply the '@wrapt.decorator' to it.
 
-```
+```python
 def wrapper(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 ```
@@ -194,7 +194,7 @@ def wrapper(wrapped, instance, args, kwargs):
 To add the wrapper function to a target function we now use the
 'wrapt.wrap_function_wrapper()' function.
 
-```
+```python
 class Example(object):
     def name(self):
         return 'name'
@@ -207,7 +207,7 @@ wrapt.wrap_function_wrapper(Example, 'name', wrapper)
 In this case we had the class in the same code file, but we could also have
 done:
 
-```
+```python
 import example
 
 import wrapt
@@ -222,7 +222,7 @@ to apply the wrapper to.
 We could also skip importing the module altogether and just used the name
 of the module.
 
-```
+```python
 import wrapt
 
 wrapt.wrap_function_wrapper('example', 'Example.name', wrapper)
@@ -231,7 +231,7 @@ wrapt.wrap_function_wrapper('example', 'Example.name', wrapper)
 Just to prove that just about anything can be simplified by the user of a
 decorator, we finally could write the whole thing as:
 
-```
+```python
 import wrapt
 
 @wrapt.patch_function_wrapper('example', 'Example.name')
@@ -260,13 +260,13 @@ In particular, it the target function you were trying to monkey patch was a
 normal global function of the module, some other code could have grabbed a
 direct reference to it by doing:
 
-```
+```python
 from example import function
 ```
 
 If you come along later and have:
 
-```
+```python
 import wrapt
 
 @wrapt.patch_function_wrapper('example', 'function')

--- a/blog/12-using-wrapt-to-support-testing-of-software.md
+++ b/blog/12-using-wrapt-to-support-testing-of-software.md
@@ -31,7 +31,7 @@ Return values and side effects
 If one is using Mock and you want to temporarily override the value
 returned by a method of a class when called, one way is to use:
 
-```
+```python
 from mock import Mock, patch
 
 class ProductionClass(object):
@@ -49,7 +49,7 @@ def test_method(mock_method):
 With what I have presented so far of the wrapt package, an equivalent way
 of doing this would be:
 
-```
+```python
 from wrapt import patch_function_wrapper
 
 class ProductionClass(object):
@@ -75,11 +75,11 @@ unit test function being run at that time. So the patch should be
 removed at the end of that test and before the next function is called.
 
 For that scenario, the wrapt package provides an alternate decorator
-'@wrapt.transient_function_wrapper'. This can be used to create a wrapper
+`@wrapt.transient_function_wrapper`. This can be used to create a wrapper
 function that will only be applied for the scope of a specific call that
 the decorated function is applied to. We can therefore write the above as:
 
-```
+```python
 from wrapt import transient_function_wrapper
 
 class ProductionClass(object):
@@ -106,7 +106,7 @@ the return value being passed back from the lower layers.
 For this blog post when I tried to work out how to do that with Mock the
 general approach I came up with was the following.
 
-```
+```python
 from mock import Mock, patch
 
 class ProductionClass(object):
@@ -127,9 +127,9 @@ def test_method(mock_method):
     result = real.method(3, 4, 5, key='value')
 ```
 
-There were two tricks here. The first is the 'autospec=True' argument to
-'@Mock.patch' to have it perform method binding, and the second being the
-need to capture the original method from the 'ProductionClass' before any
+There were two tricks here. The first is the `autospec=True` argument to
+`@mock.patch` to have it perform method binding, and the second being the
+need to capture the original method from the `ProductionClass` before any
 mock had been applied to it, so I could then in turn call it when the side
 effect function for the mock was called.
 
@@ -144,7 +144,7 @@ nothing special has to be done when wrapping methods. Further, when the
 wrapt wrapper function is called, it is always passed the original function
 which was wrapped, so no magic is needed to stash that away.
 
-```
+```python
 from wrapt import transient_function_wrapper
 
 class ProductionClass(object):
@@ -184,7 +184,7 @@ to then intercept when it is called.
 
 In the case of using Mock I would do something like:
 
-```
+```python
 from mock import Mock, patch
 
 def function():
@@ -215,7 +215,7 @@ def test_method(mock_method):
 
 And with wrapt I would instead do:
 
-```
+```python
 from wrapt import transient_function_wrapper, function_wrapper
 
 def function():
@@ -241,9 +241,9 @@ def test_method():
 ```
 
 In this example I have used a new decorator called
-'@wrapt.function_wrapper'. I could also have used '@wrapt.decorator' in
-this example. The '@wrapt.function_wrapper' decorator is actually just a
-cut down version of '@wrapt.decorator', lacking some of the bells and
+`@wrapt.function_wrapper`. I could also have used `@wrapt.decorator` in
+this example. The `@wrapt.function_wrapper` decorator is actually just a
+cut down version of `@wrapt.decorator`, lacking some of the bells and
 whistles that one doesn't generally need when doing explicit monkey
 patching, but otherwise it can be used in the same way.
 
@@ -266,7 +266,7 @@ this with wrapt.
 The first approach is to replace the method on the instance directly with a
 wrapper which encapsulates the original method.
 
-```
+```python
 from wrapt import transient_function_wrapper, function_wrapper
 
 class StorageClass(object):
@@ -323,7 +323,7 @@ We can therefore avoid needing to change the original object itself.
 
 For this example what we can therefore do is:
 
-```
+```python
 from wrapt import transient_function_wrapper, ObjectProxy
 
 class StorageClass(object):
@@ -360,7 +360,7 @@ necessary.
 With the proxy we can even intercept access to an attribute of the original
 object by adding a property to the proxy object.
 
-```
+```python
 from wrapt import transient_function_wrapper, ObjectProxy
 
 class StorageClass(object):
@@ -413,7 +413,7 @@ I therefore leave you with one final example to get you thinking about the
 ways this might be done if you are partial to the way that Mock does
 things.
 
-```
+```python
 from wrapt import transient_function_wrapper
 
 class ProductionClass(object):

--- a/blog/13-ordering-issues-when-monkey-patching-in-python.md
+++ b/blog/13-ordering-issues-when-monkey-patching-in-python.md
@@ -15,8 +15,8 @@ Coincidentally, Ned Batchelder recently [posted](
 http://nedbatchelder.com//blog/201503/finding_temp_file_creators.html)
 about using monkey patching to debug an issue where temporary directories
 were not being cleaned up properly. Ned described this exact issue in
-relation to wanting to monkey patch the 'mkdtemp()' function from the
-'tempfile' module. In that case he was able to find an alternate place
+relation to wanting to monkey patch the `mkdtemp()` function from the
+`tempfile` module. In that case he was able to find an alternate place
 within the private implementation for the module to patch so as to avoid
 the problem. Using some internal function like this may not always be
 possible however.
@@ -37,7 +37,7 @@ Post import hook mechanism
 
 In PEP 369, a primary use case presented was illustrated by the example:
 
-```
+```python
 import imp
 
 @imp.when_imported('decimal')
@@ -57,7 +57,7 @@ Instead of using the decorator '@imp.when_imported' decorator, one could
 also explicitly use the 'imp.register_post_import_hook()' function to
 register a post import hook.
 
-```
+```python
 import imp
 
 def register(decimal):
@@ -68,7 +68,7 @@ imp.register_post_import_hook(register, 'decimal')
 
 Although PEP 369 was never incorporated into Python, the wrapt module
 provides implementations for both the decorator and the function, but
-within the 'wrapt' module rather than 'imp'.
+within the `wrapt` module rather than `imp`.
 
 Now what neither the decorator or the function really solved alone was the
 ordering issue. That is, you still had the problem that these could be
@@ -95,7 +95,7 @@ than import the monkey patching code, you can setup a registration which
 would only lazily load the monkey patching code itself if the module to be
 patched was imported, and then execute it.
 
-```
+```python
 import sys
 
 from wrapt import register_post_import_hook
@@ -110,9 +110,9 @@ def load_and_execute(name):
 register_post_import_hook(load_and_execute('patch_tempfile'), 'tempfile')
 ```
 
-In the module file 'patch_tempfile.py' we would now have:
+In the module file `patch_tempfile.py` we would now have:
 
-```
+```python
 from wrapt import wrap_function_wrapper
 
 def _mkdtemp_wrapper(wrapped, instance, args, kwargs):
@@ -128,8 +128,11 @@ Running the first script with the interactive interpreter so as to leave us
 in the interpreter, we can then show what happens when we import the
 'tempfile' module and execute the 'mkdtemp()' function.
 
-```
+```sh
 $ python -i lazyloader.py
+```
+
+```pycon
 >>> import tempfile
 patching tempfile
 >>> tempfile.mkdtemp()
@@ -179,9 +182,9 @@ src/__init__.py
 src/tempfile_debugging.py
 ```
 
-The 'setup.py' file for this package will be:
+The `setup.py` file for this package will be:
 
-```
+```python
 from setuptools import setup
 
 NAME = 'wrapt_patches.tempfile_debugging'
@@ -219,9 +222,9 @@ The key part of the 'setup.py' file is the definition of the
 to a list of definitions listing what Python modules this package contains
 monkey patches for.
 
-The 'src/__init__.py' file will then contain:
+The `src/__init__.py` file will then contain:
 
-```
+```python
 import pkgutil
 __path__ = pkgutil.extend_path(__path__, __name__)
 ```
@@ -231,7 +234,7 @@ as is required when creating a namespace package.
 Finally, the monkey patches will actually be contained in
 'src/tempfile_debugging.py' and for now is much like what we had before.
 
-```
+```python
 from wrapt import wrap_function_wrapper
 
 def _mkdtemp_wrapper(wrapped, instance, args, kwargs):
@@ -250,7 +253,7 @@ In place now of the explicit registrations which we previously added at the
 very start of the Python application main script file, we would instead
 add:
 
-```
+```python
 import os
 
 from wrapt import discover_post_import_hooks
@@ -269,8 +272,10 @@ If we were to run the application with no specific configuration to enable
 the monkey patches then nothing would happen. If however they were enabled,
 then they would be automatically discovered and applied as necessary.
 
-```
+```sh
 $ WRAPT_PATCHES=wrapt_patches.tempfile_debugging python -i entrypoints.py
+```
+```pycon
 discover wrapt_patches.tempfile_debugging
 >>> import tempfile
 patching tempfile

--- a/blog/14-automatic-patching-of-python-applications.md
+++ b/blog/14-automatic-patching-of-python-applications.md
@@ -10,7 +10,7 @@ this case is where other code has imported a reference to a function within
 a module by name and stored that in it is own namespace. In other words,
 where it has used:
 
-```
+```python
 from module import function
 ```
 
@@ -67,7 +67,7 @@ has though since also been used in the implementation of easy_install and
 if you have ever run easy-install and looked at the easy-install.pth file
 in the site-packages directory you will find some code which looks like:
 
-```
+```python
 import sys; sys.__plen = len(sys.path)
 ./antigravity-0.1-py2.7.egg
 import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)
@@ -106,7 +106,7 @@ In the previous post where I talked about the post import hook mechanism,
 the code I gave as needing to be able to be manually added at the start of
 any Python application script file was:
 
-```
+```python
 import os
 
 from wrapt import discover_post_import_hooks
@@ -142,7 +142,7 @@ presence of the environment variable.
 
 What we can therefore use in our ‘.pth’ is:
 
-```
+```python
 import os, sys; os.environ.get('AUTOWRAPT_BOOTSTRAP') and __import__('autowrapt.bootstrap') and sys.modules['autowrapt.bootstrap'].bootstrap()
 ```
 
@@ -172,7 +172,7 @@ Python interpreter ‘site’ module
 The actual final parts of Python interpreter initialisation is performed
 from the main() function of the site module:
 
-```
+```python
 def main():
     global ENABLE_USER_SITE
     abs__file__()
@@ -210,7 +210,7 @@ We have to monkey patch both because the usercustomize.py processing is
 optional dependent on whether ENABLE_USER_SITE is true or not. Our
 'bootstrap() function therefore needs to look like:
 
-```
+```python
 def _execsitecustomize_wrapper(wrapped):
     def _execsitecustomize(*args, **kwargs):
         try:
@@ -247,9 +247,9 @@ ends up calling _register_bootstrap_functions() is dependent on whether
 ENABLE_USER_SITE is true or not, only calling it in execsitecustomize() if
 support for usersitecustomize was enabled.
 
-Finally we now have our '_register_bootstrap_functions()’ defined as:
+Finally we now have our `_register_bootstrap_functions()` defined as:
 
-```
+```python
 _registered = False
 
 def _register_bootstrap_functions():
@@ -270,7 +270,7 @@ We have worked out the various bits we require, but how do we get this
 installed, in particular how do we get the custom .pth file installed. For
 that we use a setup.py file of:
 
-```
+```python
 import sys
 import os
 
@@ -331,7 +331,7 @@ try it, and use it if you really want to.
 To allow for a easy quick test to see that it works, the autowrapt package
 bundles an example monkey patch. In the above setup.py this was set up by:
 
-```
+```python
 entry_points = {'autowrapt.examples’: ['this = autowrapt.examples:autowrapt_this']},
 ```
 
@@ -351,7 +351,7 @@ minimum version.
 
 Now run the command line interpreter as normal and at the prompt do:
 
-```
+```python
 import this
 ```
 
@@ -364,12 +364,12 @@ AUTOWRAPT_BOOTSTRAP=autowrapt.examples python
 ```
 
 This runs the Python interpreter again, but also sets the environment
-variable AUTOWRAPT_BOOTSTRAP with the value autowrapt.examples matching the
-name of the entry point defined in the setup.py file for autowrapt'.
+variable `AUTOWRAPT_BOOTSTRAP` with the value `autowrapt.examples` matching the
+name of the entry point defined in the setup.py file for autowrapt.
 
-The actual code for the ‘autowrapt_this()’ function was:
+The actual code for the `autowrapt_this()` function was:
 
-```
+```python
 from __future__ import print_function
 
 def autowrapt_this(module):
@@ -378,7 +378,7 @@ def autowrapt_this(module):
 
 so if we now again run:
 
-```
+```python
 import this
 ```
 


### PR DESCRIPTION
I found myself rereading your great blog posts this morning. I find code easier to read with appropriate syntax highlighting, so have added the appropriate highlighting declarations for all code blocks.