### PR TITLE
fix dummycollector for pytest >= 6

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,30 @@ import sys
 
 import pytest
 
+try:
+    from pytest import File as FileCollector
+except ImportError:
+    from pytest.collect import File as FileCollector
+
 version = tuple(sys.version_info[:2])
 
-class DummyCollector(pytest.collect.File):
+class DummyCollector(FileCollector):
     def collect(self):
         return []
 
+def construct_dummy(path, parent):
+    if hasattr(DummyCollector, "from_parent"):
+        item = DummyCollector.from_parent(parent, fspath=path)
+        return item
+    else:
+        return DummyCollector(path, parent=parent)
+
 def pytest_pycollect_makemodule(path, parent):
     if '_py33' in path.basename and version < (3, 3):
-        return DummyCollector(path, parent=parent)
+        return construct_dummy(path, parent)
     if '_py37' in path.basename and version < (3, 7):
-        return DummyCollector(path, parent=parent)
+        return construct_dummy(path, parent)
     if '_py3' in path.basename and version < (3, 0):
-        return DummyCollector(path, parent=parent)
+        return construct_dummy(path, parent)
     if '_py2' in path.basename and version >= (3, 0):
-        return DummyCollector(path, parent=parent)
+        return construct_dummy(path, parent)


### PR DESCRIPTION
The dummy collector construction for pytest >= 6 fails with

```
[   24s] ============================= test session starts ==============================
[   24s] platform linux -- Python 3.6.12, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3.6
[   24s] cachedir: .pytest_cache
[   24s] rootdir: /home/abuild/rpmbuild/BUILD/wrapt-1.12.1, configfile: tox.ini
[   24s] collecting ... collected 0 items / 1 error
[   24s] 
[   24s] ==================================== ERRORS ====================================
[   24s] ________________________ ERROR collecting test session _________________________
[   24s] Direct construction of DummyCollector has been deprecated, please use DummyCollector.from_parent.
[   24s] See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.
[   24s] =============================== warnings summary ===============================
[   24s] tests/conftest.py:7
[   24s]   /home/abuild/rpmbuild/BUILD/wrapt-1.12.1/tests/conftest.py:7: PytestDeprecationWarning: pytest.collect.File was moved to pytest.File
[   24s]   Please update to the new name.
[   24s]     class DummyCollector(pytest.collect.File):
[   24s] 
[   24s] -- Docs: https://docs.pytest.org/en/stable/warnings.html
[   24s] =========================== short test summary info ============================
[   24s] ERROR 
[   24s] !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
[   24s] ========================= 1 warning, 1 error in 0.24s ==========================
[   24s] error: Bad exit status from /var/tmp/rpm-tmp.msDIbV (%check)
```

An updated conftest.py fixes this