### PR TITLE
docs: fix simple typo, truncacted -> truncated

### DIFF
--- a/src/wrapt/importer.py
+++ b/src/wrapt/importer.py
@@ -19,7 +19,7 @@ from .decorators import synchronized
 # The dictionary registering any post import hooks to be triggered once
 # the target module has been imported. Once a module has been imported
 # and the hooks fired, the list of hooks recorded against the target
-# module will be truncacted but the list left in the dictionary. This
+# module will be truncated but the list left in the dictionary. This
 # acts as a flag to indicate that the module had already been imported.
 
 _post_import_hooks = {}


### PR DESCRIPTION
There is a small typo in src/wrapt/importer.py.

Should read `truncated` rather than `truncacted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md