### PR TITLE
Build universal2 wheel for Apple Silicon support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -207,6 +207,7 @@ jobs:
             WRAPT_INSTALL_EXTENSIONS: true
             CIBW_SKIP: pp*
             CIBW_BUILD_VERBOSITY: 1
+            CIBW_ARCHS_MACOS: "x86_64 universal2"
       - uses: actions/upload-artifact@v2
         with:
           name: dist


### PR DESCRIPTION
A universal2 binary, new with Python 3.9.1, is a macOS binary that contains Intel and Apple Silicon code. This allows macOS apps to be built and distributed on either architecture and run natively on either.