### PR TITLE
Fix threading issues with register_post_import_hook

### DIFF
--- a/src/wrapt/importer.py
+++ b/src/wrapt/importer.py
@@ -15,8 +15,6 @@ else:
     string_types = str,
     from importlib.util import find_spec
 
-from .decorators import synchronized
-
 # The dictionary registering any post import hooks to be triggered once
 # the target module has been imported. Once a module has been imported
 # and the hooks fired, the list of hooks recorded against the target
@@ -45,7 +43,6 @@ def _create_import_hook_from_string(name):
         return callback(module)
     return import_hook
 
-@synchronized(_post_import_hooks_lock)
 def register_post_import_hook(hook, name):
     # Create a deferred import hook if hook is a string name rather than
     # a callable function.
@@ -53,50 +50,27 @@ def register_post_import_hook(hook, name):
     if isinstance(hook, string_types):
         hook = _create_import_hook_from_string(hook)
 
-    # Automatically install the import hook finder if it has not already
-    # been installed.
+    with _post_import_hooks_lock:
+        # Automatically install the import hook finder if it has not already
+        # been installed.
 
-    global _post_import_hooks_init
+        global _post_import_hooks_init
 
-    if not _post_import_hooks_init:
-        _post_import_hooks_init = True
-        sys.meta_path.insert(0, ImportHookFinder())
+        if not _post_import_hooks_init:
+            _post_import_hooks_init = True
+            sys.meta_path.insert(0, ImportHookFinder())
 
-    # Determine if any prior registration of a post import hook for
-    # the target modules has occurred and act appropriately.
-
-    hooks = _post_import_hooks.get(name, None)
-
-    if hooks is None:
-        # No prior registration of post import hooks for the target
-        # module. We need to check whether the module has already been
-        # imported. If it has we fire the hook immediately and add an
-        # empty list to the registry to indicate that the module has
-        # already been imported and hooks have fired. Otherwise add
-        # the post import hook to the registry.
+        # Check if the module is already imported. If not, register the hook
+        # to be called after import.
 
         module = sys.modules.get(name, None)
+        if module is None:
+            _post_import_hooks.setdefault(name, []).append(hook)
 
-        if module is not None:
-            _post_import_hooks[name] = []
-            hook(module)
-
-        else:
-            _post_import_hooks[name] = [hook]
-
-    elif hooks == []:
-        # A prior registration of port import hooks for the target
-        # module was done and the hooks already fired. Fire the hook
-        # immediately.
-
-        module = sys.modules[name]
+    # If the module is already imported, fire the hook right away.
+    # NOTE: Call the hook outside of the lock to avoid deadlocks.
+    if module is not None:
         hook(module)
-
-    else:
-        # A prior registration of port import hooks for the target
-        # module was done but the module has not yet been imported.
-
-        _post_import_hooks[name].append(hook)
 
 # Register post import hooks defined as package entry points.
 
@@ -124,16 +98,14 @@ def discover_post_import_hooks(group):
 # exception is raised in any of the post import hooks, that will cause
 # the import of the target module to fail.
 
-@synchronized(_post_import_hooks_lock)
 def notify_module_loaded(module):
     name = getattr(module, '__name__', None)
-    hooks = _post_import_hooks.get(name, None)
+    with _post_import_hooks_lock:
+        hooks = _post_import_hooks.pop(name, ())
 
-    if hooks:
-        _post_import_hooks[name] = []
-
-        for hook in hooks:
-            hook(module)
+    # NOTE: Call hooks outside of the lock to avoid deadlocks.
+    for hook in hooks:
+        hook(module)
 
 # A custom module import finder. This intercepts attempts to import
 # modules and watches out for attempts to import target modules of
@@ -181,14 +153,14 @@ class ImportHookFinder:
     def __init__(self):
         self.in_progress = {}
 
-    @synchronized(_post_import_hooks_lock)
     def find_module(self, fullname, path=None):
         # If the module being imported is not one we have registered
         # post import hooks for, we can return immediately. We will
         # take no further part in the importing of this module.
 
-        if not fullname in _post_import_hooks:
-            return None
+        with _post_import_hooks_lock:
+            if fullname not in _post_import_hooks:
+                return None
 
         # When we are interested in a specific module, we will call back
         # into the import system a second time to defer to the import
@@ -244,8 +216,9 @@ class ImportHookFinder:
         # post import hooks for, we can return immediately. We will
         # take no further part in the importing of this module.
 
-        if not fullname in _post_import_hooks:
-            return None
+        with _post_import_hooks_lock:
+            if fullname not in _post_import_hooks:
+                return None
 
         # When we are interested in a specific module, we will call back
         # into the import system a second time to defer to the import

--- a/tests/module1.py
+++ b/tests/module1.py
@@ -1,0 +1,2 @@
+import time
+time.sleep(0.1)  # simulate slow code

--- a/tests/module2.py
+++ b/tests/module2.py
@@ -1,0 +1,2 @@
+import time
+time.sleep(0.1)  # simulate slow code

--- a/tests/test_post_import_hooks.py
+++ b/tests/test_post_import_hooks.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import unittest
 import sys
+import threading
 
 import wrapt
 from wrapt.importer import _post_import_hooks
@@ -14,10 +15,8 @@ class TestPostImportHooks(unittest.TestCase):
         # So we can import 'this' and test post-import hooks multiple times
         # below in the context of a single Python process, remove 'this' from
         # sys.modules and post import hooks.
-        if 'this' in sys.modules:
-            del sys.modules['this']
-        if 'this' in _post_import_hooks:
-            del _post_import_hooks['this']
+        sys.modules.pop('this', None)
+        _post_import_hooks.pop('this', None)
 
     def test_before_import(self):
         invoked = []
@@ -71,6 +70,56 @@ class TestPostImportHooks(unittest.TestCase):
 
         self.assertEqual(len(invoked_one), 1)
         self.assertEqual(len(invoked_two), 1)
+
+    def test_remove_from_sys_modules(self):
+        invoked = []
+
+        @wrapt.when_imported('this')
+        def hook_this(module):
+            self.assertEqual(module.__name__, 'this')
+            invoked.append(1)
+
+        import this
+        self.assertEqual(len(invoked), 1)
+
+        del sys.modules['this']
+        wrapt.register_post_import_hook(hook_this, 'this')
+        import this
+        self.assertEqual(len(invoked), 2)
+
+    def test_import_deadlock(self):
+        @wrapt.when_imported('this')
+        def hook_this(module):
+            ev.set()
+            # The hook used to be called under _post_import_hooks_lock. Then
+            # the import tried to acquire the import lock. If the other thread
+            # already held it and was waiting for _post_import_hooks_lock, we
+            # deadlocked.
+            for _ in range(5):
+                import module1
+                del sys.modules['module1']
+
+        def worker():
+            ev.wait()
+            # The import tries to acquire the import lock. ImportHookFinder
+            # then tries to acquire _post_import_hooks_lock under it.
+            for _ in range(5):
+                import module2
+                del sys.modules['module2']
+
+        # A deadlock between notify_module_loaded and ImportHookFinder.
+        ev = threading.Event()
+        thread = threading.Thread(target=worker)
+        thread.start()
+        import this
+        thread.join()
+
+        # A deadlock between register_post_import_hook and ImportHookFinder.
+        ev = threading.Event()
+        thread = threading.Thread(target=worker)
+        thread.start()
+        wrapt.register_post_import_hook(hook_this, 'this')
+        thread.join()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. Add a missing lock to ImportHookFinder.find_spec(). It should have
the same lock as find_module() since it accesses _post_import_hooks.

2. Fix a deadlock between notify_module_loaded() and ImportHookFinder.
This occurs because the former is calling import hooks under
_post_import_hooks_lock. If a hook is making any imports itself while
another thread is also making imports, the thread can grab the import
lock and wait for _post_import_hooks_lock in ImportHookFinder, while the
hook already has _post_import_hooks_lock and is waiting for the import
lock. This results in a deadlock. The solution is to call the hooks
outside of _post_import_hooks_lock.

Same for register_post_import_hook() and  ImportHookFinder.

3. Also fix an issue if register_post_import_hook() was called after a
module was already imported but was later removed from sys.modules. This
also makes the logic simpler.