### PR TITLE
make wrapt a PEP561 typed package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,6 @@ include LICENSE
 
 recursive-include src *.c
 recursive-include tests *.py requirements.txt
+
+include src/wrapt/py.typed
+include src/wrapt/wrapt.pyi

--- a/src/wrapt/wrapt.pyi
+++ b/src/wrapt/wrapt.pyi
@@ -1,0 +1,13 @@
+from typing import Any, Generic, TypeVar, Callable, Optional
+
+F = TypeVar('F', bound=Callable[..., Any])
+A = TypeVar('A', bound=Callable[..., Any])
+T = TypeVar("T", bound=Any)
+
+def decorator(wrapper: F, enabled: Optional[bool] = None, adapter: Optional[A] = None) -> F: ...
+
+class ObjectProxy(Generic[T]):
+    __wrapped__ : T
+
+    def __init__(self, wrapped: T):
+        ...


### PR DESCRIPTION
not sure if the name have to be "wrapt.pyi" or "py.typed" - that needs to be tested.