### PR TITLE
Remove python<3.8 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,11 @@ jobs:
         os:
           - ubuntu-20.04
         python-version:
-          # - 2.7
-          # - 3.5
-          - 3.6
-          - 3.7
           - 3.8
           - 3.9
           - "3.10"
           - 3.11
           - 3.12
-          # - pypy-2.7
           - pypy-3.8
           - pypy-3.9
           - pypy-3.10
@@ -55,7 +50,6 @@ jobs:
   #   strategy:
   #     matrix:
   #       python:
-  #         #- {os: ubuntu-20.04,  python-version: 3.7, pyver: py37}
   #         #- {os: ubuntu-20.04,  python-version: 3.8, pyver: py38}
   #         #- {os: ubuntu-20.04,  python-version: 3.9, pyver: py39}
   #         - {os: ubuntu-20.04,  python-version: "3.10", pyver: py310}
@@ -91,16 +85,11 @@ jobs:
         os:
           - macos-latest
         python-version:
-          # - 2.7
-          # - 3.5
-          - 3.6
-          - 3.7
           - 3.8
           - 3.9
           - "3.10"
           - 3.11
           - 3.12
-          # - pypy-2.7
           - pypy-3.8
           - pypy-3.9
           - pypy-3.10
@@ -123,29 +112,6 @@ jobs:
         name: coverage
         path: .coverage.*
 
-  # test_windows_py27:
-  #   name: Test (${{ matrix.os }}, ${{ matrix.python-version }})
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os:
-  #         - windows-latest
-  #       python-version:
-  #         - 2.7
-  #   steps:
-  #   - name: Checkout code
-  #     uses: actions/checkout@v3
-  #   - name: Setup Python ${{ matrix.python-version }}
-  #     uses: actions/setup-python@v4
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #   - name: Update pip
-  #     run: python -m pip install -U pip wheel setuptools
-  #   - name: Install tox
-  #     run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
-  #   - name: Test with tox
-  #     run: python -m tox -e py27,py27-without-extensions
-
   test_windows:
     name: Test (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
@@ -154,15 +120,11 @@ jobs:
         os:
           - windows-latest
         python-version:
-          # - 3.5
-          - 3.6
-          - 3.7
           - 3.8
           - 3.9
           - "3.10"
           - 3.11
           - 3.12
-          # - pypy-2.7
           - pypy-3.8
           - pypy-3.9
           - pypy-3.10
@@ -278,7 +240,6 @@ jobs:
     needs:
     - test_linux
     - test_macos
-    # - test_windows_py27
     - test_windows
     runs-on: ubuntu-20.04
     steps:

--- a/docs/benchmarks.py
+++ b/docs/benchmarks.py
@@ -29,7 +29,7 @@ def wrapper4(wrapped, *args, **kwargs):
 def function4():
     pass
 
-class Class(object):
+class Class:
 
     def function1(self):
         pass

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # wrapt documentation build configuration file, created by
 # sphinx-quickstart on Tue Aug 13 20:38:04 2013.
@@ -40,8 +39,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'wrapt'
-copyright = u'2013-2023, Graham Dumpleton'
+project = 'wrapt'
+copyright = '2013-2023, Graham Dumpleton'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -189,8 +188,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'wrapt.tex', u'wrapt Documentation',
-   u'Graham Dumpleton', 'manual'),
+  ('index', 'wrapt.tex', 'wrapt Documentation',
+   'Graham Dumpleton', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -219,8 +218,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'wrapt', u'wrapt Documentation',
-     [u'Graham Dumpleton'], 1)
+    ('index', 'wrapt', 'wrapt Documentation',
+     ['Graham Dumpleton'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -233,8 +232,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'wrapt', u'wrapt Documentation',
-   u'Graham Dumpleton', 'wrapt', 'One line description of project.',
+  ('index', 'wrapt', 'wrapt Documentation',
+   'Graham Dumpleton', 'wrapt', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/src/wrapt/decorators.py
+++ b/src/wrapt/decorators.py
@@ -53,7 +53,7 @@ from .__wrapt__ import (FunctionWrapper, BoundFunctionWrapper, ObjectProxy,
 class _AdapterFunctionCode(CallableObjectProxy):
 
     def __init__(self, wrapped_code, adapter_code):
-        super(_AdapterFunctionCode, self).__init__(wrapped_code)
+        super().__init__(wrapped_code)
         self._self_adapter_code = adapter_code
 
     @property
@@ -79,7 +79,7 @@ class _AdapterFunctionCode(CallableObjectProxy):
 class _AdapterFunctionSurrogate(CallableObjectProxy):
 
     def __init__(self, wrapped, adapter):
-        super(_AdapterFunctionSurrogate, self).__init__(wrapped)
+        super().__init__(wrapped)
         self._self_adapter = adapter
 
     @property
@@ -129,7 +129,7 @@ class AdapterWrapper(FunctionWrapper):
 
     def __init__(self, *args, **kwargs):
         adapter = kwargs.pop('adapter')
-        super(AdapterWrapper, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._self_surrogate = _AdapterFunctionSurrogate(
                 self.__wrapped__, adapter)
         self._self_adapter = adapter
@@ -154,13 +154,13 @@ class AdapterWrapper(FunctionWrapper):
     def __signature__(self):
         return self._self_surrogate.__signature__
 
-class AdapterFactory(object):
+class AdapterFactory:
     def __call__(self, wrapped):
         raise NotImplementedError()
 
 class DelegatedAdapterFactory(AdapterFactory):
     def __init__(self, factory):
-        super(DelegatedAdapterFactory, self).__init__()
+        super().__init__()
         self.factory = factory
     def __call__(self, wrapped):
         return self.factory(wrapped)
@@ -226,7 +226,7 @@ def decorator(wrapper=None, enabled=None, adapter=None, proxy=FunctionWrapper):
                             adapter = adapter[:-1]
                         adapter = formatargspec(*adapter)
 
-                    exec_('def adapter{}: pass'.format(adapter), ns, ns)
+                    exec_(f'def adapter{adapter}: pass', ns, ns)
                     adapter = ns['adapter']
 
                     # Override the annotations for the manufactured

--- a/src/wrapt/importer.py
+++ b/src/wrapt/importer.py
@@ -133,7 +133,7 @@ class _ImportHookLoader:
 class _ImportHookChainedLoader(ObjectProxy):
 
     def __init__(self, loader):
-        super(_ImportHookChainedLoader, self).__init__(loader)
+        super().__init__(loader)
 
         if hasattr(loader, "load_module"):
           self.__self_setattr__('load_module', self._self_load_module)

--- a/src/wrapt/patches.py
+++ b/src/wrapt/patches.py
@@ -68,7 +68,7 @@ def wrap_object(module, name, factory, args=(), kwargs={}):
 # instance attribute. Note that this cannot be used on attributes which
 # are themselves defined by a property object.
 
-class AttributeWrapper(object):
+class AttributeWrapper:
 
     def __init__(self, attribute, factory, args, kwargs):
         self.attribute = attribute

--- a/src/wrapt/weakrefs.py
+++ b/src/wrapt/weakrefs.py
@@ -53,11 +53,11 @@ class WeakFunctionProxy(ObjectProxy):
                     _callback)
 
             if wrapped._self_parent is not None:
-                super(WeakFunctionProxy, self).__init__(
+                super().__init__(
                         weakref.proxy(wrapped._self_parent, _callback))
 
             else:
-                super(WeakFunctionProxy, self).__init__(
+                super().__init__(
                         weakref.proxy(wrapped, _callback))
 
             return
@@ -65,13 +65,13 @@ class WeakFunctionProxy(ObjectProxy):
         try:
             self._self_instance = weakref.ref(wrapped.__self__, _callback)
 
-            super(WeakFunctionProxy, self).__init__(
+            super().__init__(
                     weakref.proxy(wrapped.__func__, _callback))
 
         except AttributeError:
             self._self_instance = None
 
-            super(WeakFunctionProxy, self).__init__(
+            super().__init__(
                     weakref.proxy(wrapped, _callback))
 
     def __call__(*args, **kwargs):

--- a/src/wrapt/wrappers.py
+++ b/src/wrapt/wrappers.py
@@ -13,7 +13,7 @@ def with_metaclass(meta, *bases):
     """Create a base class with a metaclass."""
     return meta("NewBase", bases, {})
 
-class _ObjectProxyMethods(object):
+class _ObjectProxyMethods:
 
     # We use properties to override the values of __module__ and
     # __doc__. If we add these in ObjectProxy, the derived class
@@ -495,7 +495,7 @@ class _FunctionWrapperBase(ObjectProxy):
     def __init__(self, wrapped, instance, wrapper, enabled=None,
             binding='function', parent=None):
 
-        super(_FunctionWrapperBase, self).__init__(wrapped)
+        super().__init__(wrapped)
 
         object.__setattr__(self, '_self_instance', instance)
         object.__setattr__(self, '_self_wrapper', wrapper)
@@ -780,5 +780,5 @@ class FunctionWrapper(_FunctionWrapperBase):
         else:
             binding = 'function'
 
-        super(FunctionWrapper, self).__init__(wrapped, None, wrapper,
+        super().__init__(wrapped, None, wrapper,
                 enabled, binding)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import inspect
 import types
@@ -140,7 +138,7 @@ class TestDynamicAdapter(unittest.TestCase):
         def _wrapper_1(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class1(object):
+        class Class1:
             @_wrapper_1
             def function(self):
                 pass
@@ -156,7 +154,7 @@ class TestDynamicAdapter(unittest.TestCase):
         def _wrapper_2(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class2(object):
+        class Class2:
             @_wrapper_2
             def function(self):
                 pass
@@ -175,7 +173,7 @@ class TestDynamicAdapter(unittest.TestCase):
         def _wrapper_1(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class1(object):
+        class Class1:
             @_wrapper_1
             @classmethod
             def function(cls):
@@ -192,7 +190,7 @@ class TestDynamicAdapter(unittest.TestCase):
         def _wrapper_2(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class2(object):
+        class Class2:
             @_wrapper_2
             @classmethod
             def function(self):

--- a/tests/test_adapter_py3.py
+++ b/tests/test_adapter_py3.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import inspect
 import unittest
 import types
@@ -148,7 +146,7 @@ class TestDynamicAdapterWithAnnotations(unittest.TestCase):
         def _wrapper_1(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class1(object):
+        class Class1:
             @_wrapper_1
             def function(self):
                 pass
@@ -171,7 +169,7 @@ class TestDynamicAdapterWithAnnotations(unittest.TestCase):
         def _wrapper_2(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class2(object):
+        class Class2:
             @_wrapper_2
             def function(self):
                 pass
@@ -190,7 +188,7 @@ class TestDynamicAdapterWithAnnotations(unittest.TestCase):
         def _wrapper_1(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class1(object):
+        class Class1:
             @_wrapper_1
             @classmethod
             def function(cls):
@@ -214,7 +212,7 @@ class TestDynamicAdapterWithAnnotations(unittest.TestCase):
         def _wrapper_2(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class2(object):
+        class Class2:
             @_wrapper_2
             @classmethod
             def function(self):

--- a/tests/test_adapter_py33.py
+++ b/tests/test_adapter_py33.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import inspect
 import types

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt
@@ -26,5 +24,5 @@ class TestArguments(unittest.TestCase):
         def function(a=2):
             pass
 
-        kwargs = { u'b': 40 }
+        kwargs = { 'b': 40 }
         self.assertRaises(TypeError, wrapt.getcallargs, function, **kwargs)

--- a/tests/test_attribute_wrapper.py
+++ b/tests/test_attribute_wrapper.py
@@ -1,10 +1,8 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt
 
-class Class(object):
+class Class:
     def __init__(self, value):
         self.value = value
 

--- a/tests/test_callable_object_proxy.py
+++ b/tests/test_callable_object_proxy.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import inspect
 import types
@@ -19,7 +17,7 @@ def passthru_decorator(wrapped, instance, args, kwargs):
 decorators = types.ModuleType('decorators')
 exec_(DECORATORS_CODE, decorators.__dict__, decorators.__dict__)
 
-class class1(object):
+class class1:
     pass
 
 class1o = class1
@@ -40,13 +38,13 @@ class TestInheritance(unittest.TestCase):
             return wrapped(*args, **kwargs)
 
         @passthru
-        class BaseClass(object):
+        class BaseClass:
             def __init__(self):
                 self.value = 1
 
         class DerivedClass(BaseClass.__wrapped__):
             def __init__(self):
-                super(DerivedClass, self).__init__()
+                super().__init__()
                 self.value = 2
 
         base = BaseClass()

--- a/tests/test_class_py37.py
+++ b/tests/test_class_py37.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import inspect
 import types
@@ -16,13 +14,13 @@ class TestInheritance(unittest.TestCase):
             return wrapped(*args, **kwargs)
 
         @passthru
-        class BaseClass(object):
+        class BaseClass:
             def __init__(self):
                 self.value = 1
 
         class DerivedClass(BaseClass):
             def __init__(self):
-                super(DerivedClass, self).__init__()
+                super().__init__()
                 self.value = 2
 
         base = BaseClass()
@@ -49,11 +47,11 @@ class TestInheritance(unittest.TestCase):
             return wrapped(*args, **kwargs)
 
         @passthru
-        class BaseClass1(object):
+        class BaseClass1:
             pass
 
         @passthru
-        class BaseClass2(object):
+        class BaseClass2:
             pass
 
         class DerivedClass(BaseClass1, BaseClass2):
@@ -75,7 +73,7 @@ class TestInheritance(unittest.TestCase):
             return wrapped(*args, **kwargs)
 
         @passthru
-        class CommonClass(object):
+        class CommonClass:
             pass
 
         @passthru

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import copy

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt
@@ -26,7 +24,7 @@ class TestDecorator(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
-        class Instance(object):
+        class Instance:
             def __init__(self):
                 self.count = 0
             @wrapt.decorator
@@ -54,7 +52,7 @@ class TestDecorator(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
-        class Instance(object):
+        class Instance:
             count = 0
             @wrapt.decorator
             @classmethod
@@ -81,7 +79,7 @@ class TestDecorator(unittest.TestCase):
         _kwargs = {'one': 1, 'two': 2}
 
         @wrapt.decorator
-        class ClassDecorator(object):
+        class ClassDecorator:
             def __call__(self, wrapped, instance, args, kwargs):
                 return wrapped(*args, **kwargs)
 
@@ -98,7 +96,7 @@ class TestDecorator(unittest.TestCase):
         _kwargs = {'one': 1, 'two': 2}
 
         @wrapt.decorator
-        class ClassDecorator(object):
+        class ClassDecorator:
             def __init__(self, arg):
                 assert arg == 1
             def __call__(self, wrapped, instance, args, kwargs):

--- a/tests/test_descriptors_py36.py
+++ b/tests/test_descriptors_py36.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt
@@ -23,7 +21,7 @@ class TestObjectDescriptors(unittest.TestCase):
             def __get__(self, instance, owner=None):
                 return self.__wrapped__.__get__(instance, owner)
 
-        class Instance(object):
+        class Instance:
             @_decorator
             @_descriptor_wrapper
             def method(self):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import inspect
 import types

--- a/tests/test_function_wrapper.py
+++ b/tests/test_function_wrapper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt
@@ -25,7 +23,7 @@ class TestClassInheritence(unittest.TestCase):
         def _decorator(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @_decorator
             def function(self, args, **kwargs):
                 return args, kwargs
@@ -43,7 +41,7 @@ class TestClassInheritence(unittest.TestCase):
         def _decorator(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @_decorator
             @classmethod
             def function(cls, *args, **kwargs):
@@ -62,7 +60,7 @@ class TestClassInheritence(unittest.TestCase):
         def _decorator(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @_decorator
             @staticmethod
             def function(*args, **kwargs):
@@ -96,7 +94,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             def function1(self, *args, **kwargs):
                 return args, kwargs
             function2 = decorator2(function1)
@@ -116,7 +114,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             @classmethod
             def function1(cls, *args, **kwargs):
                 return args, kwargs
@@ -137,7 +135,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function1(*args, **kwargs):
                 return args, kwargs
@@ -152,7 +150,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             def function1(self, *args, **kwargs):
                 return args, kwargs
 
@@ -171,7 +169,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             @classmethod
             def function1(cls, *args, **kwargs):
                 return args, kwargs
@@ -186,7 +184,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function1(*args, **kwargs):
                 return args, kwargs
@@ -205,7 +203,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             def function1(self, *args, **kwargs):
                 return args, kwargs
 
@@ -225,7 +223,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             @classmethod
             def function1(cls, *args, **kwargs):
                 return args, kwargs
@@ -240,7 +238,7 @@ class TestAttributeAccess(unittest.TestCase):
             return wrapped(*args, **kwargs)
         decorator2 = wrapt.decorator(decorator1)
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function1(*args, **kwargs):
                 return args, kwargs
@@ -356,7 +354,7 @@ class TestGuardArgument(unittest.TestCase):
         self.assertTrue(isinstance(function, wrapt.FunctionWrapper))
 
     def test_boolean_dynamic_guard_on_decorator(self):
-        class Guard(object):
+        class Guard:
             value = True
             def __nonzero__(self):
                 return self.value
@@ -429,7 +427,7 @@ class TestGuardArgument(unittest.TestCase):
             result.append(1)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @_decorator
             def function(self):
                 pass
@@ -564,7 +562,7 @@ class TestInvalidCalling(unittest.TestCase):
         def _decorator(wrapped, instance, args, kwargs):
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @_decorator
             def method(self):
                 pass

--- a/tests/test_inheritance_py37.py
+++ b/tests/test_inheritance_py37.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import abc

--- a/tests/test_inner_classmethod.py
+++ b/tests/test_inner_classmethod.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import types
 
@@ -18,7 +16,7 @@ def passthru_decorator(wrapped, instance, args, kwargs):
 decorators = types.ModuleType('decorators')
 exec_(DECORATORS_CODE, decorators.__dict__, decorators.__dict__)
 
-class Class(object):
+class Class:
     @classmethod
     def function(self, arg):
         '''documentation'''
@@ -26,7 +24,7 @@ class Class(object):
 
 Original = Class
 
-class Class(object):
+class Class:
     @decorators.passthru_decorator
     @classmethod
     def function(self, arg):
@@ -136,7 +134,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @classmethod
             def _function(cls, *args, **kwargs):
@@ -163,7 +161,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @classmethod
             def _function(cls, *args, **kwargs):
@@ -190,7 +188,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @_decorator
             @classmethod
@@ -218,7 +216,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @_decorator
             @classmethod
@@ -237,7 +235,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def _function(cls, *args, **kwargs):
                 return (args, kwargs)
@@ -262,7 +260,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def _function(cls, *args, **kwargs):
                 return (args, kwargs)
@@ -287,7 +285,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def _function(cls, *args, **kwargs):
                 return (args, kwargs)
@@ -313,7 +311,7 @@ class TestCallingInnerClassMethod(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {'one': 1, 'two': 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def _function(cls, *args, **kwargs):
                 return (args, kwargs)

--- a/tests/test_inner_staticmethod.py
+++ b/tests/test_inner_staticmethod.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import types
 
@@ -18,7 +16,7 @@ def passthru_decorator(wrapped, instance, args, kwargs):
 decorators = types.ModuleType('decorators')
 exec_(DECORATORS_CODE, decorators.__dict__, decorators.__dict__)
 
-class Class(object):
+class Class:
     @staticmethod
     def function(self, arg):
         '''documentation'''
@@ -26,7 +24,7 @@ class Class(object):
 
 Original = Class
 
-class Class(object):
+class Class:
     @decorators.passthru_decorator
     @staticmethod
     def function(self, arg):
@@ -136,7 +134,7 @@ class TestCallingInnerStaticMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @staticmethod
             def _function(*args, **kwargs):
@@ -163,7 +161,7 @@ class TestCallingInnerStaticMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @staticmethod
             def _function(*args, **kwargs):
@@ -190,7 +188,7 @@ class TestCallingInnerStaticMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @_decorator
             @staticmethod
@@ -218,7 +216,7 @@ class TestCallingInnerStaticMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @_decorator
             @staticmethod
@@ -243,7 +241,7 @@ class TestCallingInnerStaticMethod(unittest.TestCase):
             self.assertEqual(kwargs, _kwargs)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @staticmethod
             def _function(*args, **kwargs):
                 return (args, kwargs)
@@ -268,7 +266,7 @@ class TestCallingInnerStaticMethod(unittest.TestCase):
             self.assertEqual(kwargs, _kwargs)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             @staticmethod
             def _function(*args, **kwargs):
                 return (args, kwargs)

--- a/tests/test_instancemethod.py
+++ b/tests/test_instancemethod.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import inspect
 import types
@@ -122,14 +120,14 @@ class TestNamingInstanceMethodOldStyle(unittest.TestCase):
         self.assertTrue(isinstance(OldClass1d().function,
                 type(OldClass1o().function)))
 
-class NewClass1(object):
+class NewClass1:
     def function(self, arg):
         '''documentation'''
         return arg
 
 NewClass1o = NewClass1
 
-class NewClass1(object):
+class NewClass1:
     @decorators.passthru_decorator
     def function(self, arg):
         '''documentation'''
@@ -361,7 +359,7 @@ class TestCallingInstanceMethodNewStyle(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             def _function(self, *args, **kwargs):
                 return (args, kwargs)
@@ -389,7 +387,7 @@ class TestCallingInstanceMethodNewStyle(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             def _function(self, *args, **kwargs):
                 return (args, kwargs)
@@ -418,7 +416,7 @@ class TestCallingInstanceMethodNewStyle(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @_decorator
             def _function(self, *args, **kwargs):
@@ -447,7 +445,7 @@ class TestCallingInstanceMethodNewStyle(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @_decorator
             @_decorator
             def _function(self, *args, **kwargs):

--- a/tests/test_memoize.py
+++ b/tests/test_memoize.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import threading
 import inspect
@@ -34,7 +32,7 @@ def memoize(wrapped, instance, args, kwargs):
 def function1(count, text):
     return count * text
 
-class C1(object):
+class C1:
 
     @memoize
     def function1(self, count, text):

--- a/tests/test_monkey_patching.py
+++ b/tests/test_monkey_patching.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import sys
 
@@ -26,11 +24,11 @@ def global_function_3_enabled_callable(*args, **kwargs):
 def global_function_4(*args, **kwargs):
     return args, kwargs
 
-class Class_1(object):
+class Class_1:
     def method(self, *args, **kwargs):
         return args, kwargs
 
-class Class_2(object):
+class Class_2:
     @classmethod
     def method(cls, *args, **kwargs):
         return cls, args, kwargs
@@ -41,7 +39,7 @@ class Class_2_1(Class_2):
 class Class_2_2(Class_2_1):
     pass
 
-class Class_3(object):
+class Class_3:
     @staticmethod
     def method(*args, **kwargs):
         return args, kwargs
@@ -81,7 +79,7 @@ class TestMonkeyPatching(unittest.TestCase):
 
         _self = self
 
-        class wrapper(object):
+        class wrapper:
             @wrapt.function_wrapper
             def __call__(self, wrapped, instance, args, kwargs):
                 _self.assertEqual(type(self), wrapper)
@@ -107,7 +105,7 @@ class TestMonkeyPatching(unittest.TestCase):
 
         called = []
 
-        class wrapper(object):
+        class wrapper:
             @wrapt.function_wrapper
             @classmethod
             def __call__(cls, wrapped, instance, args, kwargs):
@@ -416,7 +414,7 @@ class TestMonkeyPatching(unittest.TestCase):
 
         _self = self
 
-        class wrapper(object):
+        class wrapper:
             @wrapt.transient_function_wrapper(__name__,
                     'TestMonkeyPatching._test_transient_function_wrapper')
             def __call__(self, wrapped, instance, args, kwargs):
@@ -453,7 +451,7 @@ class TestExplicitMonkeyPatching(unittest.TestCase):
             self.assertEqual(kwargs, _kwargs)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -481,7 +479,7 @@ class TestExplicitMonkeyPatching(unittest.TestCase):
             self.assertEqual(kwargs, _kwargs)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -509,7 +507,7 @@ class TestExplicitMonkeyPatching(unittest.TestCase):
             self.assertEqual(kwargs, _kwargs)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -537,7 +535,7 @@ class TestExplicitMonkeyPatching(unittest.TestCase):
             self.assertEqual(kwargs, _kwargs)
             return wrapped(*args, **kwargs)
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 

--- a/tests/test_nested_function.py
+++ b/tests/test_nested_function.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import types
 

--- a/tests/test_object_proxy.py
+++ b/tests/test_object_proxy.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import types
 import sys
@@ -428,7 +426,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -442,7 +440,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -456,7 +454,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -470,7 +468,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -484,7 +482,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -498,7 +496,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -512,7 +510,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -526,7 +524,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             def function(self, *args, **kwargs):
                 return args, kwargs
 
@@ -540,7 +538,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -555,7 +553,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -570,7 +568,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -585,7 +583,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -600,7 +598,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -615,7 +613,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -630,7 +628,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -645,7 +643,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, *args, **kwargs):
                 return args, kwargs
@@ -660,7 +658,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -675,7 +673,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -690,7 +688,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -705,7 +703,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -720,7 +718,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -735,7 +733,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -750,7 +748,7 @@ class TestCallingObject(unittest.TestCase):
         _args = ()
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -765,7 +763,7 @@ class TestCallingObject(unittest.TestCase):
         _args = (1, 2)
         _kwargs = {"one": 1, "two": 2}
 
-        class Class(object):
+        class Class:
             @staticmethod
             def function(*args, **kwargs):
                 return args, kwargs
@@ -790,7 +788,7 @@ class TestIterObjectProxy(unittest.TestCase):
 class TestContextManagerObjectProxy(unittest.TestCase):
 
     def test_context_manager(self):
-        class Class(object):
+        class Class:
             def __enter__(self):
                 return self
             def __exit__(*args, **kwargs):
@@ -1463,7 +1461,7 @@ class TestAsNumberObjectProxy(unittest.TestCase):
         self.assertEqual(hex(value), hex(20))
 
     def test_index(self):
-        class Class(object):
+        class Class:
             def __index__(self):
                 return 1
         value = wrapt.ObjectProxy(Class())
@@ -1590,11 +1588,11 @@ class TestDerivedClassCreation(unittest.TestCase):
         class DerivedObjectProxy(wrapt.ObjectProxy):
 
             def __new__(cls, wrapped):
-                instance = super(DerivedObjectProxy, cls).__new__(cls)
+                instance = super().__new__(cls)
                 instance.__init__(wrapped)
 
             def __init__(self, wrapped):
-                super(DerivedObjectProxy, self).__init__(wrapped)
+                super().__init__(wrapped)
 
         def function():
             pass
@@ -1607,7 +1605,7 @@ class TestDerivedClassCreation(unittest.TestCase):
 
             def __init__(self, wrapped):
                 self._self_attribute = True
-                super(DerivedObjectProxy, self).__init__(wrapped)
+                super().__init__(wrapped)
 
         def function():
             pass
@@ -1685,7 +1683,7 @@ class DerivedClassAttributes(unittest.TestCase):
 
         class DerivedObjectProxy(wrapt.ObjectProxy):
             def __init__(self, wrapped):
-                super(DerivedObjectProxy, self).__init__(wrapped)
+                super().__init__(wrapped)
                 self._self_attribute = 1
             @property
             def ATTRIBUTE(self):
@@ -1749,7 +1747,7 @@ class OverrideAttributeAccess(unittest.TestCase):
             def __getattr__(self, name):
                 accessed.append(name)
                 try:
-                    __getattr__ = super(DerivedObjectProxy, self).__getattr__
+                    __getattr__ = super().__getattr__
                 except AttributeError as e:
                     raise RuntimeError(str(e))
                 return __getattr__(name)
@@ -1798,7 +1796,7 @@ class SpecialMethods(unittest.TestCase):
 
     def test_class_bytes(self):
         if PY3:
-            class Class(object):
+            class Class:
                 def __bytes__(self):
                     return b'BYTES'
             instance = Class()

--- a/tests/test_outer_classmethod.py
+++ b/tests/test_outer_classmethod.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import types
 
@@ -18,7 +16,7 @@ def passthru_decorator(wrapped, instance, args, kwargs):
 decorators = types.ModuleType('decorators')
 exec_(DECORATORS_CODE, decorators.__dict__, decorators.__dict__)
 
-class Class(object):
+class Class:
     @classmethod
     def function(self, arg):
         '''documentation'''
@@ -26,7 +24,7 @@ class Class(object):
 
 Original = Class
 
-class Class(object):
+class Class:
     @classmethod
     @decorators.passthru_decorator
     def function(self, arg):
@@ -151,7 +149,7 @@ class TestCallingOuterClassMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @classmethod
             @_decorator
             def _function(cls, *args, **kwargs):
@@ -193,7 +191,7 @@ class TestCallingOuterClassMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @classmethod
             @_decorator
             def _function(cls, *args, **kwargs):

--- a/tests/test_outer_staticmethod.py
+++ b/tests/test_outer_staticmethod.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import types
 
@@ -18,7 +16,7 @@ def passthru_decorator(wrapped, instance, args, kwargs):
 decorators = types.ModuleType('decorators')
 exec_(DECORATORS_CODE, decorators.__dict__, decorators.__dict__)
 
-class Class(object):
+class Class:
     @staticmethod
     def function(self, arg):
         '''documentation'''
@@ -26,7 +24,7 @@ class Class(object):
 
 Original = Class
 
-class Class(object):
+class Class:
     @staticmethod
     @decorators.passthru_decorator
     def function(self, arg):
@@ -139,7 +137,7 @@ class TestCallingOuterStaticMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @staticmethod
             @_decorator
             def _function(*args, **kwargs):
@@ -170,7 +168,7 @@ class TestCallingOuterStaticMethod(unittest.TestCase):
         def _function(*args, **kwargs):
             return args, kwargs
 
-        class Class(object):
+        class Class:
             @staticmethod
             @_decorator
             def _function(*args, **kwargs):

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import pickle

--- a/tests/test_post_import_hooks.py
+++ b/tests/test_post_import_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import sys
 import threading
@@ -12,7 +10,7 @@ from compat import PY2, PY3
 class TestPostImportHooks(unittest.TestCase):
 
     def setUp(self):
-        super(TestPostImportHooks, self).setUp()
+        super().setUp()
 
         # So we can import 'this' and test post-import hooks multiple times
         # below in the context of a single Python process, remove 'this' from

--- a/tests/test_synchronized_lock.py
+++ b/tests/test_synchronized_lock.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt
@@ -10,7 +8,7 @@ from compat import PYXY
 def function():
     print('function')
 
-class C1(object):
+class C1:
 
     @wrapt.synchronized
     def function1(self):
@@ -29,14 +27,14 @@ class C1(object):
 c1 = C1()
 
 @wrapt.synchronized
-class C2(object):
+class C2:
     pass
 
 @wrapt.synchronized
 class C3:
     pass
 
-class C4(object):
+class C4:
 
     # Prior to Python 3.9, this yields undesirable results due to how
     # class method is implemented. The classmethod doesn't bind the
@@ -58,7 +56,7 @@ class C4(object):
 
 c4 = C4()
 
-class C5(object):
+class C5:
 
     def __bool__(self):
         return False

--- a/tests/test_update_attributes.py
+++ b/tests/test_update_attributes.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import wrapt

--- a/tests/test_weak_function_proxy.py
+++ b/tests/test_weak_function_proxy.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import gc
 
@@ -62,7 +60,7 @@ class TestWeakFunctionProxy(unittest.TestCase):
         self.assertEqual(id(proxy), result[0])
 
     def test_instancemethod_delete_instance(self):
-        class Class(object):
+        class Class:
             def function(self, a, b):
                 return a, b
 
@@ -84,7 +82,7 @@ class TestWeakFunctionProxy(unittest.TestCase):
         self.assertEqual(id(proxy), result[0])
 
     def test_instancemethod_delete_function(self):
-        class Class(object):
+        class Class:
             def function(self, a, b):
                 return a, b
 
@@ -107,7 +105,7 @@ class TestWeakFunctionProxy(unittest.TestCase):
         self.assertEqual(id(proxy), result[0])
 
     def test_instancemethod_delete_function_and_instance(self):
-        class Class(object):
+        class Class:
             def function(self, a, b):
                 return a, b
 
@@ -130,7 +128,7 @@ class TestWeakFunctionProxy(unittest.TestCase):
         self.assertEqual(id(proxy), result[0])
 
     def test_classmethod(self):
-        class Class(object):
+        class Class:
             @classmethod
             def function(cls, a, b):
                 self.assertEqual(cls, Class)
@@ -152,7 +150,7 @@ class TestWeakFunctionProxy(unittest.TestCase):
         self.assertEqual(id(proxy), result[0])
 
     def test_staticmethod(self):
-        class Class(object):
+        class Class:
             @staticmethod
             def function(a, b):
                 return a, b
@@ -177,7 +175,7 @@ class TestWeakFunctionProxy(unittest.TestCase):
         def bark(wrapped, instance, args, kwargs):
             return 'bark'
 
-        class Animal(object):
+        class Animal:
             @bark
             def squeal(self):
                 return 'squeal'


### PR DESCRIPTION
According to https://endoflife.date/python python 3.8.x support will be EOSed in 31 Oct 2024.
This PR removed python<3.8 support using `pyupgrade --py38` and some additional manual changes.