### PR TITLE
feat: add universal2 arch for macos builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,6 +218,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             arch: aarch64
+          - os: macos-13
+            arch: universal2
+          - os: macos-14
+            arch: universal2
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU


### PR DESCRIPTION
@GrahamDumpleton I realized that what I needed was a `universal2` binary for `wrapt` on macos. I made a PR on my fork [here](https://github.com/thomasrockhu-codecov/wrapt/pull/1) which should have what you need to approve, but let me know if this works for you