### PR TITLE
declare the public api

### DIFF
--- a/src/wrapt/__init__.py
+++ b/src/wrapt/__init__.py
@@ -54,6 +54,5 @@ __all__ = (
 
     "register_post_import_hook",
     "when_imported",
-    "notify_module_loaded",
     "discover_post_import_hooks",
 )

--- a/src/wrapt/__init__.py
+++ b/src/wrapt/__init__.py
@@ -28,3 +28,32 @@ from inspect import getcallargs
 # bundled implementation here in case any user of wrapt was also needing it.
 
 from .arguments import formatargspec
+
+__all__ = (
+    "ObjectProxy",
+    "CallableObjectProxy",
+    "FunctionWrapper",
+    "BoundFunctionWrapper",
+    "PartialCallableObjectProxy",
+
+    "resolve_path",
+    "apply_patch",
+    "wrap_object",
+    "wrap_object_attribute",
+    "function_wrapper",
+    "wrap_function_wrapper",
+    "patch_function_wrapper",
+    "transient_function_wrapper",
+
+    "WeakFunctionProxy"
+
+    "adapter_factory",
+    "AdapterFactory",
+    "decorator",
+    "synchronized",
+
+    "register_post_import_hook",
+    "when_imported",
+    "notify_module_loaded",
+    "discover_post_import_hooks",
+)


### PR DESCRIPTION
From [docs.python.org](https://docs.python.org/3/reference/simple_stmts.html):

> `__all__` should contain the entire public API. It is intended to avoid accidentally exporting items that are not part of the API (such as library modules which were imported and used within the module).