### PR TITLE
Remove the dependency on `pkg_resources` and hence `setuptools`

### DIFF
--- a/src/wrapt/importer.py
+++ b/src/wrapt/importer.py
@@ -93,24 +93,19 @@ def _create_import_hook_from_entrypoint(entrypoint):
                 callback = getattr(callback, attr)
         return callback(module)
     
-    def import_hook_legacy(module):
-        __import__(entrypoint.module_name)
-        callback = sys.modules[entrypoint.module_name]
-        for attr in entrypoint.attrs:
-            callback = getattr(callback, attr)
-        return callback(module)
-    
-    if sys.version_info < (3, 10):
-        return import_hook_legacy
     return import_hook
 
 def discover_post_import_hooks(group):
-    if sys.version_info >= (3, 10):
-        from importlib.metadata import entry_points
-    else:
-        from pkg_resources import iter_entry_points as entry_points
+    from importlib.metadata import entry_points
 
-    for entrypoint in entry_points(group=group):
+    try:
+        # Python 3.10+ style with select parameter
+        entrypoints = entry_points(group=group)
+    except TypeError:
+        # Python 3.8-3.9 style that returns a dict
+        entrypoints = entry_points().get(group, ())
+        
+    for entrypoint in entrypoints:
         entrypoint.load()
         callback = _create_import_hook_from_entrypoint(entrypoint)
         register_post_import_hook(callback, entrypoint.name)

--- a/src/wrapt/importer.py
+++ b/src/wrapt/importer.py
@@ -82,20 +82,36 @@ def register_post_import_hook(hook, name):
 
 def _create_import_hook_from_entrypoint(entrypoint):
     def import_hook(module):
+        entrypoint_value = entrypoint.value.split(":")
+        module_name = entrypoint_value[0]
+        __import__(module_name)
+        callback = sys.modules[module_name]
+
+        if len(entrypoint_value) > 1:
+            attrs = entrypoint_value[1].split(".")
+            for attr in attrs:
+                callback = getattr(callback, attr)
+        return callback(module)
+    
+    def import_hook_legacy(module):
         __import__(entrypoint.module_name)
         callback = sys.modules[entrypoint.module_name]
         for attr in entrypoint.attrs:
             callback = getattr(callback, attr)
         return callback(module)
+    
+    if sys.version_info < (3, 10):
+        return import_hook_legacy
     return import_hook
 
 def discover_post_import_hooks(group):
-    try:
-        import pkg_resources
-    except ImportError:
-        return
+    if sys.version_info >= (3, 10):
+        from importlib.metadata import entry_points
+    else:
+        from pkg_resources import iter_entry_points as entry_points
 
-    for entrypoint in pkg_resources.iter_entry_points(group=group):
+    for entrypoint in entry_points(group=group):
+        entrypoint.load()
         callback = _create_import_hook_from_entrypoint(entrypoint)
         register_post_import_hook(callback, entrypoint.name)
 


### PR DESCRIPTION
`setuptools` is not included with the standard library since `Python>=3.12`

Although `importlib.metadata` was introduced in python 3.8, we get the below error in `Python < 3.10`
```
entry_points() got an unexpected keyword argument 'group'
```