### PR TITLE
feature/build riscv64 wheel

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -301,7 +301,7 @@ jobs:
             CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.9"
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.os }}-${{ matrix.arch }}
+          name: dist-py3.8-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*.whl
 
   bdist_wheel:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -10,7 +10,6 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+dev[0-9]+"
 
 jobs:
-
   test_linux:
     name: Test (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
@@ -41,7 +40,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
     - name: Store partial coverage reports
@@ -102,7 +101,7 @@ jobs:
       - name: Install tox
         run: docker exec python_rv64  bash -c "source /src/venv/bin/activate && python -m pip install 'tox<4.0.0' 'tox-gh-actions<3.0.0'"
       - name: Install mypy
-        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && python -m pip install 'mypy'"
+        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && python -m pip install 'mypy==1.17.1'"
       - name: Test with tox
         run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && cd /src && python -m tox -e '${{ matrix.python-version.tox_e }}'"
 
@@ -139,7 +138,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
     - name: Store partial coverage reports
@@ -178,7 +177,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
     - name: Store partial coverage reports
@@ -232,7 +231,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
 
@@ -264,8 +263,8 @@ jobs:
         name: sdist
         path: dist/*
 
-  bdist_wheel:
-    name: Build wheels (3.8+) on ${{ matrix.os }} for ${{ matrix.arch }}
+  bdist_wheel_py38:
+    name: Build wheels (3.8) on ${{ matrix.os }} for ${{ matrix.arch }}
     needs:
     - test_linux
     - test_linux_no_gil
@@ -275,7 +274,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
         arch: [auto]
         include:
           - os: ubuntu-latest
@@ -299,23 +298,38 @@ jobs:
             CIBW_BUILD_VERBOSITY: 1
             CIBW_ARCHS: ${{ matrix.arch }}
             CIBW_FREE_THREADED_SUPPORT: 1
+            CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8,<3.9"
       - uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*.whl
 
-  bdist_riscv64_wheel:
+  bdist_wheel:
     name: Build wheels (3.9+) on ${{ matrix.os }} for ${{ matrix.arch }}
     needs:
-      - test_linux_riscv64
+    - test_linux
+    - test_linux_no_gil
+    #- test_aarch64_linux
+    - test_macos
+    - test_windows
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        arch: [riscv64]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-13, macos-14]
+        arch: [auto]
+        include:
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: macos-13
+            arch: universal2
+          - os: macos-14
+            arch: universal2
+          - os: ubuntu-latest
+            arch: riscv64
     steps:
       - uses: actions/checkout@v5
       - name: Set up QEMU
+        if: ${{ matrix.arch == 'aarch64' || matrix.arch == 'riscv64' }}
         uses: docker/setup-qemu-action@v3
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.4

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.18.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
     - name: Store partial coverage reports
@@ -101,7 +101,7 @@ jobs:
       - name: Install tox
         run: docker exec python_rv64  bash -c "source /src/venv/bin/activate && python -m pip install 'tox<4.0.0' 'tox-gh-actions<3.0.0'"
       - name: Install mypy
-        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && python -m pip install 'mypy==1.17.1'"
+        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && python -m pip install 'mypy==1.18.1'"
       - name: Test with tox
         run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && cd /src && python -m tox -e '${{ matrix.python-version.tox_e }}'"
 
@@ -138,7 +138,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.18.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
     - name: Store partial coverage reports
@@ -177,7 +177,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.18.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
     - name: Store partial coverage reports
@@ -231,7 +231,7 @@ jobs:
     - name: Install tox
       run: python -m pip install "tox<4.0.0" "tox-gh-actions<3.0.0"
     - name: Install mypy
-      run: python -m pip install "mypy==1.17.1; python_version >= '3.9'"
+      run: python -m pip install "mypy==1.18.1; python_version >= '3.9'"
     - name: Test with tox
       run: python -m tox
 

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -268,7 +268,6 @@ jobs:
     needs:
     - test_linux
     - test_linux_no_gil
-    #- test_aarch64_linux
     - test_macos
     - test_windows
     runs-on: ${{ matrix.os }}
@@ -309,7 +308,7 @@ jobs:
     needs:
     - test_linux
     - test_linux_no_gil
-    #- test_aarch64_linux
+    - test_linux_riscv64
     - test_macos
     - test_windows
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -52,6 +52,7 @@ jobs:
   test_linux_riscv64:
     name: Test (${{ matrix.os }} riscv64-${{ matrix.python-version.tox_e }})
     runs-on: ${{ matrix.os }}
+    if: false
     strategy:
       matrix:
         os:
@@ -308,7 +309,7 @@ jobs:
     needs:
     - test_linux
     - test_linux_no_gil
-    - test_linux_riscv64
+    # - test_linux_riscv64
     - test_macos
     - test_windows
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -50,6 +50,72 @@ jobs:
         name: coverage-${{ matrix.os }}-${{ matrix.python-version }}
         path: .coverage.*
 
+  test_linux_riscv64:
+    name: Test (${{ matrix.os }} riscv64-${{ matrix.python-version.tox_e }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        python-version:
+          - {
+              "python_image": 3.9.23,
+              "tox_e": "py39, py39-without-extensions, py39-install-extensions, py39-disable-extensions",
+            }
+          - {
+              "python_image": 3.10.18,
+              "tox_e": "py310, py310-without-extensions, py310-install-extensions, py310-disable-extensions",
+            }
+          - {
+              "python_image": 3.11.13,
+              "tox_e": "py311, py311-without-extensions, py311-install-extensions, py311-disable-extensions",
+            }
+          - {
+              "python_image": 3.12.11,
+              "tox_e": "py312, py312-without-extensions, py312-install-extensions, py312-disable-extensions",
+            }
+          - {
+              "python_image": 3.13.7,
+              "tox_e": "py313, py313-without-extensions, py313-install-extensions, py313-disable-extensions",
+            }
+          - {
+              "python_image": 3.14.0rc2,
+              "tox_e": "py314, py314-without-extensions, py314-install-extensions, py314-disable-extensions",
+            }
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup docker/setup-qemu-action
+        uses: docker/setup-qemu-action@v3
+
+      - name: start python_rv64
+        run: docker run --platform linux/riscv64 -d --name python_rv64 -v ./:/src python:${{ matrix.python-version.python_image }} bash -c "while true; do sleep 30; done"
+
+      - name: show uname
+        run: docker exec python_rv64 uname -a
+
+      - name: setup venv
+        run: docker exec python_rv64 python -m venv /src/venv
+      - name: Update pip
+        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && python -m pip install -U pip wheel setuptools"
+      - name: Install tox
+        run: docker exec python_rv64  bash -c "source /src/venv/bin/activate && python -m pip install 'tox<4.0.0' 'tox-gh-actions<3.0.0'"
+      - name: Install mypy
+        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && python -m pip install 'mypy'"
+      - name: Test with tox
+        run: docker exec python_rv64 bash -c "source /src/venv/bin/activate && cd /src && python -m tox -e '${{ matrix.python-version.tox_e }}'"
+
+      - name: ls -al
+        run: ls -al | grep .coverage
+
+      - name: Store partial coverage reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.python-version.python_image }}
+          path: .coverage.*
+          include-hidden-files: true
+
   test_linux_no_gil:
     name: Test - NO GIL (${{ matrix.os }}, ${{ matrix.python-version }})
     runs-on: ubuntu-latest
@@ -233,6 +299,34 @@ jobs:
             CIBW_BUILD_VERBOSITY: 1
             CIBW_ARCHS: ${{ matrix.arch }}
             CIBW_FREE_THREADED_SUPPORT: 1
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.os }}-${{ matrix.arch }}
+          path: dist/*.whl
+
+  bdist_riscv64_wheel:
+    name: Build wheels (3.9+) on ${{ matrix.os }} for ${{ matrix.arch }}
+    needs:
+      - test_linux_riscv64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        arch: [riscv64]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.1.4
+        with:
+          output-dir: dist
+        env:
+          WRAPT_INSTALL_EXTENSIONS: true
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ENABLE: cpython-freethreading
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
       - uses: actions/upload-artifact@v4
         with:
           name: dist-${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
PyPI recently added support for RISC-V, so we might consider adding support for RISC-V 64.

I used docker+qemu to test the code under riscv64. Below are the CI results:
[Build, test and create release packages.](https://github.com/ffgan/wrapt/actions/runs/17174568995)

The results are generally well presented.

Since there is no python3.8+riscv64 container on docker hub, I set the riscv64 support to >=3.9

Feel free to contact me anytime, I'll be happy to answer any questions you have.


Other Info
Co-authored by: [nijincheng@iscas.ac.cn](mailto:nijincheng@iscas.ac.cn);