### PR TITLE
Raise ReferenceError when bound method instance is garbage collected

### DIFF
--- a/src/wrapt/weakrefs.py
+++ b/src/wrapt/weakrefs.py
@@ -108,6 +108,9 @@ class WeakFunctionProxy(BaseObjectProxy):
         # function we need to rebind the function and then call it. If
         # not just called the wrapped function.
 
+        if self._self_instance is not None and instance is None:
+            raise ReferenceError("weakly-referenced object no longer exists")
+
         if instance is None:
             return self.__wrapped__(*args, **kwargs)
 

--- a/src/wrapt/weakrefs.py
+++ b/src/wrapt/weakrefs.py
@@ -103,13 +103,17 @@ class WeakFunctionProxy(BaseObjectProxy):
         instance = self._self_instance and self._self_instance()
         function = self.__wrapped__ and self.__wrapped__
 
+        # If the wrapped function was originally a bound method but the
+        # instance it was bound to has been garbage collected, raise a
+        # ReferenceError rather than silently calling it as unbound.
+
+        if self._self_instance is not None and instance is None:
+            raise ReferenceError("weakly-referenced object no longer exists")
+
         # If the wrapped function was originally a bound function, for
         # which we retained a reference to the instance and the unbound
         # function we need to rebind the function and then call it. If
         # not just called the wrapped function.
-
-        if self._self_instance is not None and instance is None:
-            raise ReferenceError("weakly-referenced object no longer exists")
 
         if instance is None:
             return self.__wrapped__(*args, **kwargs)


### PR DESCRIPTION
`WeakFunctionProxy.__call__` checks `self._self_instance` (a `weakref.ref`) for truthiness to detect expired references, but `weakref.ref` objects are always truthy — even after the referent has been garbage collected. Only calling the ref and checking the return value can detect expiration.

When the instance is GC'd but the function still lives in the class dict (the typical case), the code falls through to the unbound-function path and calls the function without `self`:

```python
class MyClass:
    def method(self):
        return "hello"

obj = MyClass()
proxy = WeakFunctionProxy(obj.method)
del obj  # instance GC'd, but MyClass.method still lives

proxy()
# Expected: ReferenceError
# Actual: TypeError: method() missing 1 required positional argument: 'self'
```

The fix adds an explicit check: if `_self_instance` was set (it was a bound method) but the dereferenced value is `None`, raise `ReferenceError` directly.
