### PR TITLE
Fix ObjectProxy.__delattr__ missing __annotations__ special case

### DIFF
--- a/src/wrapt/wrappers.py
+++ b/src/wrapt/wrappers.py
@@ -283,6 +283,10 @@ class ObjectProxy(with_metaclass(_ObjectProxyMetaType)):  # type: ignore[misc]
             object.__delattr__(self, name)
             delattr(self.__wrapped__, name)
 
+        elif name == "__annotations__":
+            object.__delattr__(self, name)
+            delattr(self.__wrapped__, name)
+
         elif hasattr(type(self), name):
             object.__delattr__(self, name)
 


### PR DESCRIPTION
`ObjectProxy.__setattr__` has special handling for both `__qualname__` and `__annotations__`, forwarding operations to both the proxy object itself and the wrapped object. However, `__delattr__` only has special handling for `__qualname__` and misses `__annotations__`.

This means that deleting `__annotations__` on a proxy doesn't propagate to the wrapped object:

```python
import wrapt

class Foo:
    __annotations__ = {"x": int}

foo = Foo()
proxy = wrapt.ObjectProxy(foo)

proxy.__annotations__ = {"y": str}
# Both proxy and foo now have {"y": str} — correct

del proxy.__annotations__
# Only deleted from proxy, foo still has {"y": str} — incorrect
```

In `__setattr__`, both `__qualname__` and `__annotations__` are handled:

```python
elif name in ("__qualname__", "__annotations__"):
    object.__setattr__(self, name, value)
    setattr(self.__wrapped__, name, value)
```

But in `__delattr__`, only `__qualname__` is handled. This adds the matching `__annotations__` case so deletion is consistent with setting.
