### PR TITLE
Make bytes() on a proxy match bytes() on the wrapped object

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,19 @@ Version 2.3.0
   argument form works, and the argument to ``__class_getitem__()`` is now
   positional only.
 
+**Bugs Fixed**
+
+* Calling ``bytes()`` on an object proxy did not match calling ``bytes()``
+  on the wrapped object directly when the wrapped object did not implement
+  ``__bytes__()``. The C extension implementation of ``__bytes__()`` used
+  ``PyObject_Bytes()``, which only honours the ``__bytes__()`` protocol, so
+  ``bytes(wrapt.ObjectProxy(3))`` raised ``TypeError`` even though
+  ``bytes(3)`` returns a zero filled buffer. The pure Python implementation
+  already used the ``bytes()`` constructor and was unaffected. The C
+  extension now uses the ``bytes()`` constructor as well, so both
+  implementations yield the same result as using the wrapped object
+  directly.
+
 Version 2.2.2
 -------------
 

--- a/src/wrapt/_wrappers.c
+++ b/src/wrapt/_wrappers.c
@@ -2450,7 +2450,8 @@ static PyObject *WraptObjectProxy_bytes(WraptObjectProxyObject *self,
       return NULL;
   }
 
-  return PyObject_Bytes(self->wrapped);
+  return PyObject_CallFunctionObjArgs((PyObject *)&PyBytes_Type,
+                                      self->wrapped, NULL);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/tests/core/test_object_proxy.py
+++ b/tests/core/test_object_proxy.py
@@ -1932,6 +1932,16 @@ class SpecialMethods(unittest.TestCase):
 
         self.assertEqual(bytes(instance), bytes(proxy))
 
+    def test_int_bytes(self):
+        # bytes(proxy) should behave like bytes() on the wrapped object even
+        # when it has no __bytes__ (e.g. an int, where bytes(n) yields a
+        # zero-filled buffer of length n).
+        instance = 3
+
+        proxy = wrapt.ObjectProxy(instance)
+
+        self.assertEqual(bytes(instance), bytes(proxy))
+
     def test_str_format(self):
         instance = "abcd"
 


### PR DESCRIPTION
The C extension `ObjectProxy.__bytes__()` uses `PyObject_Bytes(wrapped)`, which only honours the `__bytes__()` protocol. Since the proxy always defines `__bytes__()`, `bytes()` on a proxy routes through it, so `bytes(wrapt.ObjectProxy(3))` raises `TypeError` even though `bytes(3)` returns a zero-filled buffer. The pure Python implementation already uses the `bytes()` constructor and behaves correctly.

This switches the C extension to the `bytes()` constructor as well, so both implementations match `bytes()` on the wrapped object directly (the `__bytes__()` case and `bytes()` on a `str` without an encoding are unchanged). Regression test added; it fails before the change with the `TypeError` and passes after.
